### PR TITLE
Add polymerelements/iron-behaviors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/PolymerElements/iron-dropdown",
   "dependencies": {
     "polymer": "polymer/polymer#^1.0.0",
+    "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
     "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.0.0",
     "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0",
     "neon-animation": "polymerelements/neon-animation#^1.0.0",


### PR DESCRIPTION
It seems to be required for the link line 14 in [iron-dropdown.html](https://github.com/PolymerElements/iron-dropdown/blob/master/iron-dropdown.html):
```html
<link rel="import" href="../iron-behaviors/iron-control-state.html">
```