### PR TITLE
Fix iteration over content node

### DIFF
--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -148,6 +148,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return true;
         }
 
+        if (element.nodeType !== 1) {
+          return false;
+        }
+        
         contentElements = Polymer.dom(element).querySelectorAll('content');
 
         for (contentIndex = 0; contentIndex < contentElements.length; ++contentIndex) {


### PR DESCRIPTION
The ShadowDOM tree may contain content node, which does not have `querySelectorAll` method.