### PR TITLE
fix tests, docs, and a null check

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "iron-dropdown",
   "version": "1.0.6",
-  "description": "",
+  "description": "An unstyled element that works similarly to a native browser select",
   "authors": [
     "The Polymer Authors"
   ],

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -41,6 +41,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       elementIsScrollLocked: function(element) {
         var currentLockingElement = this.currentLockingElement;
+
+        if (currentLockingElement === undefined)
+          return false;
+
         var scrollLocked;
 
         if (this._hasCachedLockedElement(element)) {

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -100,8 +100,17 @@ method is called on the element.
 
           /**
            * A pixel value that will be added to the position calculated for the
-           * given `horizontalAlign`. Use a negative value to offset to the
-           * left, or a positive value to offset to the right.
+           * given `horizontalAlign`, in the direction of alignment. You can think
+           * of it as increasing or decreasing the distance to the side of the
+           * screen given by `horizontalAlign`.
+           *
+           * If `horizontalAlign` is "left", this offset will increase or decrease
+           * the distance to the left side of the screen: a negative offset will
+           * move the dropdown to the left; a positive one, to the right.
+           *
+           * Conversely if `horizontalAlign` is "right", this offset will increase
+           * or decrease the distance to the right side of the screen: a negative
+           * offset will move the dropdown to the right; a positive one, to the left.
            */
           horizontalOffset: {
             type: Number,
@@ -111,8 +120,17 @@ method is called on the element.
 
           /**
            * A pixel value that will be added to the position calculated for the
-           * given `verticalAlign`. Use a negative value to offset towards the
-           * top, or a positive value to offset towards the bottom.
+           * given `verticalAlign`, in the direction of alignment. You can think
+           * of it as increasing or decreasing the distance to the side of the
+           * screen given by `verticalAlign`.
+           *
+           * If `verticalAlign` is "top", this offset will increase or decrease
+           * the distance to the top side of the screen: a negative offset will
+           * move the dropdown upwards; a positive one, downwards.
+           *
+           * Conversely if `verticalAlign` is "bottom", this offset will increase
+           * or decrease the distance to the bottom side of the screen: a negative
+           * offset will move the dropdown downwards; a positive one, upwards.
            */
           verticalOffset: {
             type: Number,
@@ -452,4 +470,3 @@ method is called on the element.
     })();
   </script>
 </dom-module>
-

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -35,8 +35,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="NonLockingDropdown">
     <template>
-      <iron-dropdown>
-        <div class="dropdown-content" allow-outside-scroll>I don't lock scroll!</div>
+      <iron-dropdown allow-outside-scroll>
+        <div class="dropdown-content">I don't lock scroll!</div>
       </iron-dropdown>
     </template>
   </test-fixture>
@@ -45,6 +45,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div style="display: block; position: relative; width: 100px; height: 100px;">
         <iron-dropdown horizontal-align="right" vertical-align="top">
+          <div class="dropdown-content">Hello!</div>
+        </iron-dropdown>
+      </div>
+    </template>
+  </test-fixture>
+
+  <!-- Absolutely position the dropdown so that it has enough space to move around -->
+  <test-fixture id="OffsetDropdownTopLeft">
+    <template>
+      <div style="display: block; position: absolute; top: 40px; left: 40px; width: 100px; height: 100px;">
+        <iron-dropdown>
+          <div class="dropdown-content">Hello!</div>
+        </iron-dropdown>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="OffsetDropdownBottomRight">
+    <template>
+      <div style="display: block; position: absolute; top: 40px; left: 40px; width: 100px; height: 100px;">
+        <iron-dropdown horizontal-align="right" vertical-align="bottom">
           <div class="dropdown-content">Hello!</div>
         </iron-dropdown>
       </div>
@@ -100,13 +121,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           Polymer.Base.async(function() {
             expect(elementIsVisible(content)).to.be.equal(true);
 
-            MockInteractions.downAndUp(document.body, function() {
-
+            // The document capture-click listeners are set async.
+            // Note(noms): I think this bit in iron-overlay-behavior is pretty
+            // brittle, so if the tests start failing in the future, make sure
+            // _toggleListeners is getting called at the right time.
+            Polymer.Base.async(function() {
+              MockInteractions.tap(dropdown.parentNode);
               Polymer.Base.async(function() {
                 expect(elementIsVisible(content)).to.be.equal(false);
                 done();
               }, 100);
-            });
+            }, 1);
           });
         });
 
@@ -146,11 +171,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           dropdown = fixture('NonLockingDropdown');
         });
 
-        test('can be disabled with `allowOutsideScroll`', function() {
+        test('can be disabled with `allowOutsideScroll`', function(done) {
           dropdown.open();
 
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-            .to.be.equal(false);
+          Polymer.Base.async(function() {
+            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
+              .to.be.equal(false);
+            done();
+          });
         });
       });
 
@@ -197,28 +225,98 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           }, 1);
         });
+      });
 
-        suite('with an offset', function() {
-          test('is offset by the offset value when open', function() {
-            var dropdownRect;
-            var offsetDropdownRect;
-
-            dropdown.opened = true;
-
-            Polymer.Base.async(function() {
-              dropdownRect = dropdown.getBoundingClientRect();
-
-              dropdownRect.verticalOffset = 10;
-              dropdownRect.horizontalOffset = -10;
-
-              offsetDropdownRect = dropdown.getBoundingClientRect();
-
-              expect(dropdownRect.top).to.be.equal(offsetDropdownRect.top - 10);
-              expect(dropdownRect.left).to.be.equal(offsetDropdownRect.left + 10);
-            }, 1);
-          });
+      suite('when align is left/top, with an offset', function() {
+        var dropdownRect;
+        var offsetDropdownRect;
+        var dropdown;
+        setup(function() {
+          var parent = fixture('OffsetDropdownTopLeft');
+          dropdown = parent.querySelector('iron-dropdown');
         });
 
+        test('can be offset towards the bottom right', function(done) {
+          dropdown.opened = true;
+
+          Polymer.Base.async(function() {
+            dropdownRect = dropdown.getBoundingClientRect();
+
+            dropdown.verticalOffset = 10;
+            dropdown.horizontalOffset = 10;
+            offsetDropdownRect = dropdown.getBoundingClientRect();
+
+            // verticalAlign is top, so a positive offset moves down.
+            expect(dropdownRect.top + 10).to.be.closeTo(offsetDropdownRect.top, 0.1);
+            // horizontalAlign is left, so a positive offset moves to the right.
+            expect(dropdownRect.left + 10).to.be.closeTo(offsetDropdownRect.left, 0.1);
+            done();
+          }, 1);
+        });
+
+        test('can be offset towards the top left', function(done) {
+          dropdown.opened = true;
+
+          Polymer.Base.async(function() {
+            dropdownRect = dropdown.getBoundingClientRect();
+
+            dropdown.verticalOffset = -10;
+            dropdown.horizontalOffset = -10;
+            offsetDropdownRect = dropdown.getBoundingClientRect();
+
+            // verticalAlign is top, so a negative offset moves up.
+            expect(dropdownRect.top - 10).to.be.closeTo(offsetDropdownRect.top, 0.1);
+            // horizontalAlign is left, so a negative offset moves to the left.
+            expect(dropdownRect.left - 10).to.be.closeTo(offsetDropdownRect.left, 0.1);
+            done();
+          }, 1);
+        });
+      });
+
+      suite('when align is right/bottom, with an offset', function() {
+        var dropdownRect;
+        var offsetDropdownRect;
+        var dropdown;
+        setup(function() {
+          var parent = fixture('OffsetDropdownBottomRight');
+          dropdown = parent.querySelector('iron-dropdown');
+        });
+
+        test('when align is right/bottom, can be offset towards the top left', function(done) {
+          dropdown.opened = true;
+
+          Polymer.Base.async(function() {
+            dropdownRect = dropdown.getBoundingClientRect();
+
+            dropdown.verticalOffset = 10;
+            dropdown.horizontalOffset = 10;
+            offsetDropdownRect = dropdown.getBoundingClientRect();
+
+            // verticalAlign is bottom, so a positive offset moves up.
+            expect(dropdownRect.bottom - 10).to.be.closeTo(offsetDropdownRect.bottom, 0.1);
+            // horizontalAlign is right, so a positive offset moves to the left.
+            expect(dropdownRect.right - 10).to.be.closeTo(offsetDropdownRect.right, 0.1);
+            done();
+          }, 1);
+        });
+
+        test('when align is right/bottom, can be offset towards the bottom right', function(done) {
+          dropdown.opened = true;
+
+          Polymer.Base.async(function() {
+            dropdownRect = dropdown.getBoundingClientRect();
+
+            dropdown.verticalOffset = -10;
+            dropdown.horizontalOffset = -10;
+            offsetDropdownRect = dropdown.getBoundingClientRect();
+
+            // verticalAlign is bottom, so a negative offset moves down.
+            expect(dropdownRect.bottom + 10).to.be.closeTo(offsetDropdownRect.bottom, 0.1);
+            // horizontalAlign is right, so a positive offset moves to the right.
+            expect(dropdownRect.right + 10).to.be.closeTo(offsetDropdownRect.right, 0.1);
+            done();
+          }, 1);
+        });
       });
     });
   </script>


### PR DESCRIPTION
I'm sorry this PR is so giant. I was just trying to get the tests to pass :(
- fixed the docs for the `horizontal` and `vertical` offsets, which I believe were misleading
- fixed the `offset` tests, which weren't actually running (because `done` wasn't defined)
- added more offset tests, to cover all the possible cases 
- added a null check that was triggered by the `allow-outside-scroll` test (which also wasn't running because the attribute was on the wrong element, and `done` wasn't defined)
- the `bower.json` change fixes https://github.com/PolymerElements/iron-dropdown/issues/38 