### PR TITLE
Fixes scroll lock detection in ShadowDOM

### DIFF
--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -204,13 +204,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.body.style.overflowY = 'hidden';
 
         // Modern `wheel` event for mouse wheel scrolling:
-        window.addEventListener('wheel', this._scrollInteractionHandler, true);
+        document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
-        window.addEventListener('mousewheel', this._scrollInteractionHandler, true);
+        document.addEventListener('mousewheel', this._scrollInteractionHandler, true);
         // IE:
-        window.addEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
+        document.addEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
         // Mobile devices can scroll on touch move:
-        window.addEventListener('touchmove', this._scrollInteractionHandler, true);
+        document.addEventListener('touchmove', this._scrollInteractionHandler, true);
         // Capture keydown to prevent scrolling keys (pageup, pagedown etc.)
         document.addEventListener('keydown', this._scrollInteractionHandler, true);
       },

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -220,10 +220,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.body.style.overflowX = this._originalBodyStyles.overflowX;
         document.body.style.overflowY = this._originalBodyStyles.overflowY;
 
-        window.removeEventListener('wheel', this._scrollInteractionHandler, true);
-        window.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
-        window.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
-        window.removeEventListener('touchmove', this._scrollInteractionHandler, true);
+        document.removeEventListener('wheel', this._scrollInteractionHandler, true);
+        document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
+        document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
+        document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
       }
     };

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -177,7 +177,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _scrollInteractionHandler: function(event) {
         if (Polymer
               .IronDropdownScrollManager
-              .elementIsScrollLocked(event.target)) {
+              .elementIsScrollLocked(Polymer.dom(event).rootTarget)) {
           if (event.type === 'keydown' &&
               !Polymer.IronDropdownScrollManager._isScrollingKeypress(event)) {
             return;

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -54,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ancestor = document.body;
       });
 
-      suite('contraining scroll in the DOM', function() {
+      suite('constraining scroll in the DOM', function() {
         setup(function() {
           Polymer.IronDropdownScrollManager.pushScrollLock(childOne);
         });
@@ -98,6 +98,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
             .to.be.equal(false);
+        });
+
+        suite('various scroll events', function() {
+          var scrollEvents;
+          var events;
+
+          setup(function() {
+            scrollEvents = [
+              'wheel',
+              'mousewheel',
+              'DOMMouseScroll',
+              'touchmove'
+            ];
+
+            events = scrollEvents.map(function(scrollEvent) {
+              return new CustomEvent(scrollEvent, {
+                bubbles: true,
+                cancelable: true
+              });
+            });
+          });
+
+          test('prevents wheel events from locked elements', function() {
+            events.forEach(function(event) {
+              childTwo.dispatchEvent(event);
+              expect(event.defaultPrevented).to.be.eql(true);
+            });
+          });
+
+          test('allows wheel events from unlocked elements', function() {
+            events.forEach(function(event) {
+              childOne.dispatchEvent(event);
+              expect(event.defaultPrevented).to.be.eql(false);
+            });
+          });
         });
       });
     });

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -100,6 +100,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             .to.be.equal(false);
         });
 
+        test('checking is disabled when no elements are locked', function() {
+          sinon.spy(Polymer.IronDropdownScrollManager, 'elementIsScrollLocked');
+          childOne.dispatchEvent(new CustomEvent('wheel', {
+            bubbles: true,
+            cancelable: true
+          }));
+          expect(Polymer.IronDropdownScrollManager
+              .elementIsScrollLocked.callCount).to.be.eql(1);
+          Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
+          childOne.dispatchEvent(new CustomEvent('wheel', {
+            bubbles: true,
+            cancelable: true
+          }));
+          expect(Polymer.IronDropdownScrollManager
+              .elementIsScrollLocked.callCount).to.be.eql(1);
+        });
+
         suite('various scroll events', function() {
           var scrollEvents;
           var events;

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -21,19 +21,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../iron-dropdown-scroll-manager.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="x-scrollable-element.html">
 </head>
 <body>
 
   <test-fixture id="DOMSubtree">
     <template>
-      <div id="Parent">
-        <div id="ChildOne">
-          <div id="GrandchildOne"></div>
-        </div>
-        <div id="ChildTwo">
-          <div id="GrandchildTwo"></div>
-        </div>
-      </div>
+      <x-scrollable-element id="Parent"></x-scrollable-element>
     </template>
   </test-fixture>
   <script>
@@ -47,10 +41,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       setup(function() {
         parent = fixture('DOMSubtree');
-        childOne = parent.querySelector('#ChildOne');
-        childTwo = parent.querySelector('#ChildTwo');
-        grandChildOne = parent.querySelector('#GrandchildOne');
-        grandChildTwo = parent.querySelector('#GrandchildTwo');
+        childOne = parent.$$('#ChildOne');
+        childTwo = parent.$$('#ChildTwo');
+        grandChildOne = parent.$$('#GrandchildOne');
+        grandChildTwo = parent.$$('#GrandchildTwo');
         ancestor = document.body;
       });
 
@@ -100,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             .to.be.equal(false);
         });
 
-        test('checking is disabled when no elements are locked', function() {
+        test('does not check locked elements when there are no locking elements', function() {
           sinon.spy(Polymer.IronDropdownScrollManager, 'elementIsScrollLocked');
           childOne.dispatchEvent(new CustomEvent('wheel', {
             bubbles: true,

--- a/test/x-scrollable-element.html
+++ b/test/x-scrollable-element.html
@@ -1,0 +1,27 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+
+<dom-module id="x-scrollable-element">
+  <template>
+    <div id="ChildOne">
+      <div id="GrandchildOne"></div>
+    </div>
+    <div id="ChildTwo">
+      <div id="GrandchildTwo"></div>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-scrollable-element'
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
Scroll locking was broken in ShadowDOM because `event.path` does not
contain sufficient information when `currentTarget` is `window`.
Listeners are now being added to `document` instead.