### PR TITLE
override _applyFocus. Use iron-overlay-opened in tests

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -224,6 +224,7 @@ method is called on the element.
 
         /**
          * The element that should be focused when the dropdown opens.
+         * @deprecated
          */
         get _focusTarget() {
           return this.focusTarget || this.containedElement;
@@ -322,10 +323,6 @@ method is called on the element.
             this.cancelAnimation();
             this._prepareDropdown();
             Polymer.IronOverlayBehaviorImpl._openedChanged.apply(this, arguments);
-          }
-
-          if (this.opened) {
-            this._focusContent();
           }
         },
 
@@ -477,16 +474,15 @@ method is called on the element.
         },
 
         /**
-         * Focuses the configured focus target.
+         * Apply focus to focusTarget or containedElement
          */
-        _focusContent: function() {
-          // NOTE(cdata): This is async so that it can attempt the focus after
-          // `display: none` is removed from the element.
-          this.async(function() {
-            if (this._focusTarget) {
-              this._focusTarget.focus();
-            }
-          });
+        _applyFocus: function () {
+          var focusTarget = this.focusTarget || this.containedElement;
+          if (focusTarget && this.opened && !this.noAutoFocus) {
+            focusTarget.focus();
+          } else {
+            Polymer.IronOverlayBehaviorImpl._applyFocus.apply(this, arguments);
+          }
         }
       });
     })();

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -118,6 +118,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         contentRect.height > 0;
     }
 
+    function runAfterOpen(overlay, cb) {
+      overlay.addEventListener('iron-overlay-opened', function () {
+        Polymer.Base.async(cb, 1);
+      });
+      overlay.open();
+    }
+
     suite('<iron-dropdown>', function() {
       var dropdown;
       var content;
@@ -133,31 +140,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('shows dropdown content when opened', function(done) {
-          dropdown.open();
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             expect(elementIsVisible(content)).to.be.equal(true);
             done();
           });
         });
 
         test('hides dropdown content when outside is clicked', function(done) {
-          dropdown.open();
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             expect(elementIsVisible(content)).to.be.equal(true);
-
-            // The document capture-click listeners are set async.
-            // Note(noms): I think this bit in iron-overlay-behavior is pretty
-            // brittle, so if the tests start failing in the future, make sure
-            // _toggleListeners is getting called at the right time.
+            MockInteractions.tap(dropdown.parentNode);
             Polymer.Base.async(function() {
-              MockInteractions.tap(dropdown.parentNode);
-              Polymer.Base.async(function() {
-                expect(elementIsVisible(content)).to.be.equal(false);
-                done();
-              }, 100);
-            }, 1);
+              expect(elementIsVisible(content)).to.be.equal(false);
+              done();
+            }, 10);
           });
         });
 
@@ -167,9 +163,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             content = Polymer.dom(dropdown).querySelector('.dropdown-content');
           });
           test('focuses the content when opened', function(done) {
-            dropdown.open();
-
-            Polymer.Base.async(function() {
+            runAfterOpen(dropdown, function () {
               expect(document.activeElement).to.be.equal(content);
               done();
             });
@@ -179,9 +173,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var focusableChild = Polymer.dom(content).querySelector('div[tabindex]');
             dropdown.focusTarget = focusableChild;
 
-            dropdown.open();
-
-            Polymer.Base.async(function() {
+            runAfterOpen(dropdown, function () {
               expect(document.activeElement).to.not.be.equal(content);
               expect(document.activeElement).to.be.equal(focusableChild);
               done();
@@ -198,9 +190,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
-          dropdown.open();
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
               .to.be.equal(false);
             done();
@@ -219,9 +209,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var parentRect;
           var dropdownRect;
 
-          dropdown.opened = true;
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
             parentRect = parent.getBoundingClientRect();
 
@@ -230,7 +218,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(dropdownRect.top).to.be.closeTo(parentRect.top, 0.1);
             expect(dropdownRect.right).to.be.closeTo(parentRect.right, 0.1);
             done();
-          }, 1);
+          });
         });
 
         test('can be re-aligned to the bottom', function(done) {
@@ -238,9 +226,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var dropdownRect;
 
           dropdown.verticalAlign = 'bottom';
-          dropdown.opened = true;
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             parentRect = parent.getBoundingClientRect();
             dropdownRect = dropdown.getBoundingClientRect();
 
@@ -249,7 +235,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(dropdownRect.bottom).to.be.closeTo(parentRect.bottom, 0.1);
             expect(dropdownRect.right).to.be.closeTo(parentRect.right, 0.1);
             done();
-          }, 1);
+          });
         });
       });
 
@@ -263,9 +249,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the bottom right', function(done) {
-          dropdown.opened = true;
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
 
             dropdown.verticalOffset = 10;
@@ -277,13 +261,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // horizontalAlign is left, so a positive offset moves to the right.
             expect(dropdownRect.left + 10).to.be.closeTo(offsetDropdownRect.left, 0.1);
             done();
-          }, 1);
+          });
         });
 
         test('can be offset towards the top left', function(done) {
-          dropdown.opened = true;
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
 
             dropdown.verticalOffset = -10;
@@ -295,7 +277,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // horizontalAlign is left, so a negative offset moves to the left.
             expect(dropdownRect.left - 10).to.be.closeTo(offsetDropdownRect.left, 0.1);
             done();
-          }, 1);
+          });
         });
       });
 
@@ -309,9 +291,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the top left', function(done) {
-          dropdown.opened = true;
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
 
             dropdown.verticalOffset = 10;
@@ -323,13 +303,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // horizontalAlign is right, so a positive offset moves to the left.
             expect(dropdownRect.right - 10).to.be.closeTo(offsetDropdownRect.right, 0.1);
             done();
-          }, 1);
+          });
         });
 
         test('can be offset towards the bottom right', function(done) {
-          dropdown.opened = true;
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
 
             dropdown.verticalOffset = -10;
@@ -341,7 +319,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // horizontalAlign is right, so a positive offset moves to the right.
             expect(dropdownRect.right + 10).to.be.closeTo(offsetDropdownRect.right, 0.1);
             done();
-          }, 1);
+          });
         });
       });
 
@@ -352,9 +330,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=left', function(done) {
           var parent = fixture('RTLDropdownLeft');
           dropdown = parent.querySelector('iron-dropdown');
-          dropdown.open();
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             // In RTL, if `horizontalAlign` is "left", that's the same as
             // being right-aligned in LTR. So the dropdown should be in the top
             // right corner.
@@ -368,9 +344,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=right', function(done) {
           var parent = fixture('RTLDropdownRight');
           dropdown = parent.querySelector('iron-dropdown');
-          dropdown.open();
-
-          Polymer.Base.async(function() {
+          runAfterOpen(dropdown, function () {
             // In RTL, if `horizontalAlign` is "right", that's the same as
             // being left-aligned in LTR. So the dropdown should be in the top
             // left corner.


### PR DESCRIPTION
Override `_applyFocus` for setting the focus.
Cleanup tests to use `iron-overlay-opened` event instead of timeouts.
Depends on https://github.com/PolymerElements/iron-overlay-behavior/commit/43f0ca38607846417c972cfc232253ce8637be3e (require new release of `iron-overlay-behavior`)
Fixes #57 