### PR TITLE
read scrollTop/scrollLeft only if opened

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -378,7 +378,7 @@ method is called on the element.
           var scrollTop;
           var scrollLeft;
 
-          if (containedElement) {
+          if (this.opened && containedElement) {
             scrollTop = containedElement.scrollTop;
             scrollLeft = containedElement.scrollLeft;
           }
@@ -389,7 +389,7 @@ method is called on the element.
 
           Polymer.IronOverlayBehaviorImpl._onIronResize.apply(this, arguments);
 
-          if (containedElement) {
+          if (this.opened && containedElement) {
             containedElement.scrollTop = scrollTop;
             containedElement.scrollLeft = scrollLeft;
           }

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -190,24 +190,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('should lock, only once', function(done) {
-          dropdown.open();
-
-          Polymer.Base.async(function() {
-
+          var openCount = 0;
+          runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
-                .to.be.equal(1);
-
-            // This triggers a second `pushScrollLock` with the same element, however
-            // that should not add the element to the `_lockingElements` stack twice
-            dropdown._renderOpened();
-
-            Polymer.Base.async(function() {
-              expect(Polymer.IronDropdownScrollManager._lockingElements.length)
-                .to.be.equal(1);
-              expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-                .to.be.equal(true);
+              .to.be.equal(1);
+            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
+              .to.be.equal(true);
+              
+            if(openCount === 0) {
+              // This triggers a second `pushScrollLock` with the same element, however
+              // that should not add the element to the `_lockingElements` stack twice
+              dropdown.close();
+              dropdown.open();
+            } else {
               done();
-            });
+            }
+            openCount++;
           });
         });
       });


### PR DESCRIPTION
Fixes #59 by checking if dropdown is already opened before reading the values.
Based on PR https://github.com/PolymerElements/iron-dropdown/pull/60 (so tests don't fail)