### PR TITLE
override center, handle parent's stacking context

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -143,8 +143,7 @@ method is called on the element.
            * it is opened.
            */
           positionTarget: {
-            type: Object,
-            observer: '_positionTargetChanged'
+            type: Object
           },
 
           /**
@@ -189,15 +188,6 @@ method is called on the element.
           allowOutsideScroll: {
             type: Boolean,
             value: false
-          },
-
-          /**
-           * We memoize the positionTarget bounding rectangle so that we can
-           * limit the number of times it is queried per resize / relayout.
-           * @type {?Object}
-           */
-          _positionRectMemo: {
-            type: Object
           }
         },
 
@@ -206,13 +196,13 @@ method is called on the element.
         },
 
         observers: [
-          '_updateOverlayPosition(verticalAlign, horizontalAlign, verticalOffset, horizontalOffset)'
+          '_updateOverlayPosition(positionTarget, verticalAlign, horizontalAlign, verticalOffset, horizontalOffset)'
         ],
 
         attached: function() {
-          if (this.positionTarget === undefined) {
-            this.positionTarget = this._defaultPositionTarget;
-          }
+          this.positionTarget = this.positionTarget || this._defaultPositionTarget;
+          // Memoize this to avoid expensive calculations & relayouts.
+          this._isRTL = window.getComputedStyle(this).direction == 'rtl';
         },
 
         /**
@@ -231,13 +221,6 @@ method is called on the element.
         },
 
         /**
-         * Whether the text direction is RTL
-         */
-        _isRTL: function() {
-          return window.getComputedStyle(this).direction == 'rtl';
-        },
-
-        /**
          * The element that should be used to position the dropdown when
          * it opens, if no position target is configured.
          */
@@ -252,31 +235,32 @@ method is called on the element.
         },
 
         /**
-         * The bounding rect of the position target.
+         * The horizontal align value, accounting for the RTL/LTR text direction.
          */
-        get _positionRect() {
-          if (!this._positionRectMemo && this.positionTarget) {
-            this._positionRectMemo = this.positionTarget.getBoundingClientRect();
+        get _localeHorizontalAlign() {
+          // In RTL, "left" becomes "right".
+          if (this._isRTL) {
+            return this.horizontalAlign === 'right' ? 'left' : 'right';
+          } else {
+            return this.horizontalAlign;
           }
-
-          return this._positionRectMemo;
         },
 
         /**
          * The horizontal offset value used to position the dropdown.
+         * @param {ClientRect} dropdownRect
+         * @param {ClientRect} positionRect
+         * @param {boolean=false} fromRight
+         * @return {number} pixels
+         * @private
          */
-        get _horizontalAlignTargetValue() {
+        _horizontalAlignTargetValue: function(dropdownRect, positionRect, fromRight) {
           var target;
-
-          // In RTL, the direction flips, so what is "right" in LTR becomes "left".
-          var isRTL = this._isRTL();
-          if ((!isRTL && this.horizontalAlign === 'right') ||
-              (isRTL && this.horizontalAlign === 'left')) {
-            target = document.documentElement.clientWidth - this._positionRect.right;
+          if (fromRight) {
+            target = document.documentElement.clientWidth - positionRect.right - (this._fitWidth - dropdownRect.right);
           } else {
-            target = this._positionRect.left;
+            target = positionRect.left - dropdownRect.left;
           }
-
           target += this.horizontalOffset;
 
           return Math.max(target, 0);
@@ -284,31 +268,22 @@ method is called on the element.
 
         /**
          * The vertical offset value used to position the dropdown.
+         * @param {ClientRect} dropdownRect
+         * @param {ClientRect} positionRect
+         * @param {boolean=false} fromBottom
+         * @return {number} pixels
+         * @private
          */
-        get _verticalAlignTargetValue() {
+        _verticalAlignTargetValue: function(dropdownRect, positionRect, fromBottom) {
           var target;
-
-          if (this.verticalAlign === 'bottom') {
-            target = document.documentElement.clientHeight - this._positionRect.bottom;
+          if (fromBottom) {
+            target = document.documentElement.clientHeight - positionRect.bottom - (this._fitHeight - dropdownRect.bottom);
           } else {
-            target = this._positionRect.top;
+            target = positionRect.top - dropdownRect.top;
           }
-
           target += this.verticalOffset;
 
           return Math.max(target, 0);
-        },
-
-        /**
-         * The horizontal align value, accounting for the RTL/LTR text direction.
-         */
-        get _localeHorizontalAlign() {
-          // In RTL, "left" becomes "right".
-          if (this._isRTL()) {
-            return this.horizontalAlign === 'right' ? 'left' : 'right';
-          } else {
-            return this.horizontalAlign;
-          }
         },
 
         /**
@@ -321,7 +296,8 @@ method is called on the element.
             this.cancel();
           } else {
             this.cancelAnimation();
-            this._prepareDropdown();
+            this.sizingTarget = this.containedElement || this.sizingTarget;
+            this._updateAnimationConfig();
             Polymer.IronOverlayBehaviorImpl._openedChanged.apply(this, arguments);
           }
         },
@@ -335,6 +311,9 @@ method is called on the element.
           }
 
           if (!this.noAnimations && this.animationConfig && this.animationConfig.open) {
+            if (this.withBackdrop) {
+              this.backdropElement.open();
+            }
             this.$.contentWrapper.classList.add('animating');
             this.playAnimation('open');
           } else {
@@ -348,6 +327,9 @@ method is called on the element.
         _renderClosed: function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(this);
           if (!this.noAnimations && this.animationConfig && this.animationConfig.close) {
+            if (this.withBackdrop) {
+              this.backdropElement.close();
+            }
             this.$.contentWrapper.classList.add('animating');
             this.playAnimation('close');
           } else {
@@ -364,42 +346,10 @@ method is called on the element.
         _onNeonAnimationFinish: function() {
           this.$.contentWrapper.classList.remove('animating');
           if (this.opened) {
-            Polymer.IronOverlayBehaviorImpl._renderOpened.apply(this);
+            Polymer.IronOverlayBehaviorImpl._finishRenderOpened.apply(this);
           } else {
-            Polymer.IronOverlayBehaviorImpl._renderClosed.apply(this);
+            Polymer.IronOverlayBehaviorImpl._finishRenderClosed.apply(this);
           }
-        },
-
-        /**
-         * Called when an `iron-resize` event fires.
-         */
-        _onIronResize: function() {
-          var containedElement = this.containedElement;
-          var scrollTop;
-          var scrollLeft;
-
-          if (this.opened && containedElement) {
-            scrollTop = containedElement.scrollTop;
-            scrollLeft = containedElement.scrollLeft;
-          }
-
-          if (this.opened) {
-            this._updateOverlayPosition();
-          }
-
-          Polymer.IronOverlayBehaviorImpl._onIronResize.apply(this, arguments);
-
-          if (this.opened && containedElement) {
-            containedElement.scrollTop = scrollTop;
-            containedElement.scrollLeft = scrollLeft;
-          }
-        },
-
-        /**
-         * Called when the `positionTarget` property changes.
-         */
-        _positionTargetChanged: function() {
-          this._updateOverlayPosition();
         },
 
         /**
@@ -434,43 +384,73 @@ method is called on the element.
         },
 
         /**
-         * Prepares the dropdown for opening by updating measured layout
-         * values.
+         * Updates the overlay position based on configured horizontal
+         * and vertical alignment.
          */
-        _prepareDropdown: function() {
-          this.sizingTarget = this.containedElement || this.sizingTarget;
-          this._updateAnimationConfig();
-          this._updateOverlayPosition();
+        _updateOverlayPosition: function() {
+          if (this.isAttached) {
+            // This triggers iron-resize, and iron-overlay-behavior will call refit if needed.
+            this.notifyResize();
+          }
         },
 
         /**
-         * Updates the overlay position based on configured horizontal
-         * and vertical alignment, and re-memoizes these values for the sake
-         * of behavior in `IronFitBehavior`.
+         * Useful to call this after the element, the window, or the `fitInfo`
+         * element has been resized. Will maintain the scroll position.
          */
-        _updateOverlayPosition: function() {
-          this._positionRectMemo = null;
-
-          if (!this.positionTarget) {
-            return;
+        refit: function () {
+          if (!this.opened) {
+            return
           }
+          var containedElement = this.containedElement;
+          var scrollTop;
+          var scrollLeft;
 
-          this.style[this._localeHorizontalAlign] =
-            this._horizontalAlignTargetValue + 'px';
-
-          this.style[this.verticalAlign] =
-            this._verticalAlignTargetValue + 'px';
-
-          // NOTE(cdata): We re-memoize inline styles here, otherwise
-          // calling `refit` from `IronFitBehavior` will reset inline styles
-          // to whatever they were when the dropdown first opened.
-          if (this._fitInfo) {
-            this._fitInfo.inlineStyle[this.horizontalAlign] =
-              this.style[this.horizontalAlign];
-
-            this._fitInfo.inlineStyle[this.verticalAlign] =
-              this.style[this.verticalAlign];
+          if (containedElement) {
+            scrollTop = containedElement.scrollTop;
+            scrollLeft = containedElement.scrollLeft;
           }
+          Polymer.IronFitBehavior.refit.apply(this, arguments);
+
+          if (containedElement) {
+            containedElement.scrollTop = scrollTop;
+            containedElement.scrollLeft = scrollLeft;
+          }
+        },
+
+        /**
+         * Resets the target element's position and size constraints, and clear
+         * the memoized data.
+         */
+        resetFit: function() {
+          Polymer.IronFitBehavior.resetFit.apply(this, arguments);
+
+          var hAlign = this._localeHorizontalAlign;
+          var vAlign = this.verticalAlign;
+          // Set to 0, 0 in order to discover any offset caused by parent stacking contexts.
+          this.style[hAlign] = this.style[vAlign] = '0px';
+
+          var dropdownRect = this.getBoundingClientRect();
+          var positionRect = this.positionTarget.getBoundingClientRect();
+          var horizontalValue = this._horizontalAlignTargetValue(dropdownRect, positionRect, hAlign === 'right');
+          var verticalValue = this._verticalAlignTargetValue(dropdownRect, positionRect, vAlign === 'bottom');
+
+          this.style[hAlign] = horizontalValue + 'px';
+          this.style[vAlign] = verticalValue + 'px';
+        },
+
+        /**
+         * Overridden from `IronFitBehavior`.
+         * Ensure positionedBy has correct values for horizontally & vertically.
+         */
+        _discoverInfo: function() {
+          Polymer.IronFitBehavior._discoverInfo.apply(this, arguments);
+          // Note(valdrin): in Firefox, an element with style `position: fixed; bottom: 90vh; height: 20vh`
+          // would have `getComputedStyle(element).top < 0` (instead of being `auto`) http://jsbin.com/cofired/3/edit?html,output
+          // This would cause IronFitBehavior's `constrain` to wrongly calculate sizes
+          // (it would use `top` instead of `bottom`), so we ensure we give the correct values.
+          this._fitInfo.positionedBy.horizontally = this._localeHorizontalAlign;
+          this._fitInfo.positionedBy.vertically = this.verticalAlign;
         },
 
         /**

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -28,13 +28,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     margin: 0;
     padding: 0;
   }
+
+  .container {
+    display: block;
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background-color: yellow;
+  }
+
+  .positioned {
+    position: absolute;
+    top: 40px;
+    left: 40px;
+  }
+
+  .dropdown-content {
+    width: 50px;
+    height: 50px;
+    background-color: orange;
+  }
+  
+  .full-screen {
+    width: 100vw;
+    height: 100vh;
+  }
 </style>
 <body>
 
   <test-fixture id="TrivialDropdown">
     <template>
       <iron-dropdown>
-        <div class="dropdown-content">Hello!</div>
+        <div class="dropdown-content"></div>
       </iron-dropdown>
     </template>
   </test-fixture>
@@ -49,9 +74,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="AlignedDropdown">
     <template>
-      <div style="display: block; position: relative; width: 100px; height: 100px;">
+      <div class="container">
         <iron-dropdown horizontal-align="right" vertical-align="top">
-          <div class="dropdown-content">Hello!</div>
+          <div class="dropdown-content full-screen"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -60,9 +85,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <!-- Absolutely position the dropdown so that it has enough space to move around -->
   <test-fixture id="OffsetDropdownTopLeft">
     <template>
-      <div style="display: block; position: absolute; top: 40px; left: 40px; width: 100px; height: 100px;">
+      <div class="container positioned">
         <iron-dropdown>
-          <div class="dropdown-content">Hello!</div>
+          <div class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -70,9 +95,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="OffsetDropdownBottomRight">
     <template>
-      <div style="display: block; position: absolute; top: 40px; left: 40px; width: 100px; height: 100px;">
+      <div class="container positioned">
         <iron-dropdown horizontal-align="right" vertical-align="bottom">
-          <div class="dropdown-content">Hello!</div>
+          <div class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -90,9 +115,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="RTLDropdownLeft">
     <template>
-      <div dir="rtl" style="display: block; position: relative; width: 100px; height: 100px;">
+      <div dir="rtl" class="container">
         <iron-dropdown>
-          <div class="dropdown-content">Hello!</div>
+          <div class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -100,9 +125,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="RTLDropdownRight">
     <template>
-      <div dir="rtl" style="display: block; position: relative; width: 100px; height: 100px;">
+      <div dir="rtl" class="container">
         <iron-dropdown horizontal-align="right">
-          <div class="dropdown-content">Hello!</div>
+          <div class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -196,7 +221,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               .to.be.equal(1);
             expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
               .to.be.equal(true);
-              
+
             if(openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
               // that should not add the element to the `_lockingElements` stack twice
@@ -240,11 +265,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
             parentRect = parent.getBoundingClientRect();
-
-            // NOTE(cdata): IE10 / 11 have minor rounding errors in this case,
-            // so we assert with `closeTo` and a tight threshold:
-            expect(dropdownRect.top).to.be.closeTo(parentRect.top, 0.1);
-            expect(dropdownRect.right).to.be.closeTo(parentRect.right, 0.1);
+            assert.equal(dropdownRect.top, parentRect.top, 'top ok');
+            assert.equal(dropdownRect.left, 0, 'left ok');
+            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
+            assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });
         });
@@ -257,11 +281,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function () {
             parentRect = parent.getBoundingClientRect();
             dropdownRect = dropdown.getBoundingClientRect();
+            assert.equal(dropdownRect.top, 0, 'top ok');
+            assert.equal(dropdownRect.left, 0, 'left ok');
+            assert.equal(dropdownRect.bottom, parentRect.bottom, 'bottom ok');
+            assert.equal(dropdownRect.right, parentRect.right, 'right ok');
+            done();
+          });
+        });
 
-            // NOTE(cdata): IE10 / 11 have minor rounding errors in this case,
-            // so we assert with `closeTo` and a tight threshold:
-            expect(dropdownRect.bottom).to.be.closeTo(parentRect.bottom, 0.1);
-            expect(dropdownRect.right).to.be.closeTo(parentRect.right, 0.1);
+        test('handles parent\'s stacking context', function(done) {
+          var parentRect;
+          var dropdownRect;
+          // This will create a new stacking context.
+          parent.style.transform = 'translateZ(0)';
+          runAfterOpen(dropdown, function () {
+            dropdownRect = dropdown.getBoundingClientRect();
+            parentRect = parent.getBoundingClientRect();
+            assert.equal(dropdownRect.top, parentRect.top, 'top ok');
+            assert.equal(dropdownRect.left, 0, 'left ok');
+            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
+            assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });
         });
@@ -285,9 +324,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             offsetDropdownRect = dropdown.getBoundingClientRect();
 
             // verticalAlign is top, so a positive offset moves down.
-            expect(dropdownRect.top + 10).to.be.closeTo(offsetDropdownRect.top, 0.1);
+            assert.equal(dropdownRect.top + 10, offsetDropdownRect.top, 'top ok');
             // horizontalAlign is left, so a positive offset moves to the right.
-            expect(dropdownRect.left + 10).to.be.closeTo(offsetDropdownRect.left, 0.1);
+            assert.equal(dropdownRect.left + 10, offsetDropdownRect.left, 'left ok');
             done();
           });
         });
@@ -301,9 +340,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             offsetDropdownRect = dropdown.getBoundingClientRect();
 
             // verticalAlign is top, so a negative offset moves up.
-            expect(dropdownRect.top - 10).to.be.closeTo(offsetDropdownRect.top, 0.1);
+            assert.equal(dropdownRect.top - 10, offsetDropdownRect.top, 'top ok');
             // horizontalAlign is left, so a negative offset moves to the left.
-            expect(dropdownRect.left - 10).to.be.closeTo(offsetDropdownRect.left, 0.1);
+            assert.equal(dropdownRect.left - 10, offsetDropdownRect.left, 'left ok');
             done();
           });
         });
@@ -327,9 +366,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             offsetDropdownRect = dropdown.getBoundingClientRect();
 
             // verticalAlign is bottom, so a positive offset moves up.
-            expect(dropdownRect.bottom - 10).to.be.closeTo(offsetDropdownRect.bottom, 0.1);
+            assert.equal(dropdownRect.bottom - 10, offsetDropdownRect.bottom, 'bottom ok');
             // horizontalAlign is right, so a positive offset moves to the left.
-            expect(dropdownRect.right - 10).to.be.closeTo(offsetDropdownRect.right, 0.1);
+            assert.equal(dropdownRect.right - 10, offsetDropdownRect.right, 'right ok');
             done();
           });
         });
@@ -343,9 +382,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             offsetDropdownRect = dropdown.getBoundingClientRect();
 
             // verticalAlign is bottom, so a negative offset moves down.
-            expect(dropdownRect.bottom + 10).to.be.closeTo(offsetDropdownRect.bottom, 0.1);
+            assert.equal(dropdownRect.bottom + 10, offsetDropdownRect.bottom, 'bottom ok');
             // horizontalAlign is right, so a positive offset moves to the right.
-            expect(dropdownRect.right + 10).to.be.closeTo(offsetDropdownRect.right, 0.1);
+            assert.equal(dropdownRect.right + 10, offsetDropdownRect.right, 'right ok');
             done();
           });
         });


### PR DESCRIPTION
Fixes #66, fixes #67, fixes #69 
- `resetFit` will position properly the dropdown (it takes into account parent's stacking contexts)
- `refit` is the responsible of keeping track of the scroll position (not `_onIronResize`) - now scroll position is kept also when calling `refit()`
- cleanup/removal of private methods not needed anymore
- invoke `_finishRenderOpened/_finishRenderClosed`!! Now `iron-overlay-opened/closed` is properly fired :tada:
- handle opening of backdropElement in `_renderOpened/_renderClosed` (if anyone ever used it); now the backdrop animation fires together with the dropdown animation
- limited number of relayouts (e.g. memoize `_isRTL` on `attached`)

![dropdown](https://cloud.githubusercontent.com/assets/6173664/13166232/275f087a-d67a-11e5-87e8-f321184a2012.gif)