### PR TITLE
keep overflow, calculate scroll size

### DIFF
--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -14,12 +14,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   (function() {
     'use strict';
+    // Used to calculate the scroll direction.
+    var lastTouch = null;
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
      * of authority and control over which elements in a document are currently
      * allowed to scroll.
      */
+
 
     Polymer.IronDropdownScrollManager = {
 
@@ -33,39 +36,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
       /**
-       * Returns true if the provided element is "scroll locked," which is to
-       * say that it cannot be scrolled via pointer or keyboard interactions.
+       * Returns true if the element causing the scroll is "scroll locked," which is to
+       * say that it cannot be scrolled via pointer or keyboard interactions, or
+       * if already at its scroll boundaries.
        *
-       * @param {HTMLElement} element An HTML element instance which may or may
-       * not be scroll locked.
+       * @param {Event} event The scroll event
        */
-      elementIsScrollLocked: function(element) {
-        var currentLockingElement = this.currentLockingElement;
+      shouldPreventScrolling: function(event) {
+        // Avoid expensive checks if the event is not one of the observed keys.
+        if (event.type === 'keydown' && !this._isScrollingKeypress(event)) {
+          return false;
+        }
 
+        var currentLockingElement = this.currentLockingElement;
         if (currentLockingElement === undefined)
           return false;
 
-        var scrollLocked;
-
-        if (this._hasCachedLockedElement(element)) {
-          return true;
+        var nodes = Polymer.dom(event).path;
+        var lockingIndex = nodes.indexOf(currentLockingElement);
+        var isScrollingRight = event.wheelDeltaX > 0;
+        var isScrollingUp = event.wheelDeltaY > 0;
+        if (event.type === 'touchmove' && lastTouch) {
+          isScrollingUp = event.pageY > lastTouch.pageY;
+          isScrollingRight = lastTouch.pageX > event.pageX;
         }
-
-        if (this._hasCachedUnlockedElement(element)) {
-          return false;
+        // Search for one scrollable that can still scroll, stop at the locked element.
+        for (var i = 0; i < lockingIndex; i++) {
+          var node = nodes[i];
+          // Skip nodes that are not scrollable.
+          if (node.scrollHeight <= node.clientHeight && node.scrollWidth <= node.clientWidth) {
+            continue;
+          }
+          var canScrollVertically = isScrollingUp ? node.scrollTop > 0 :
+              node.scrollTop + node.clientHeight < node.scrollHeight;
+          var canScrollHorizontally = isScrollingRight ? node.scrollLeft > 0 :
+              node.scrollLeft + node.clientWidth < node.scrollWidth;
+          // If it can scroll, don't prevent.
+          if (canScrollVertically || canScrollHorizontally) {
+            return false;
+          }
         }
-
-        scrollLocked = !!currentLockingElement &&
-          currentLockingElement !== element &&
-          !this._composedTreeContains(currentLockingElement, element);
-
-        if (scrollLocked) {
-          this._lockedElementCache.push(element);
-        } else {
-          this._unlockedElementCache.push(element);
-        }
-
-        return scrollLocked;
+        // Don't prevent if event's target is currentLockingElement.
+        return (lockingIndex !== 0);
       },
 
       /**
@@ -89,9 +101,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         this._lockingElements.push(element);
-
-        this._lockedElementCache = [];
-        this._unlockedElementCache = [];
       },
 
       /**
@@ -112,19 +121,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         this._lockingElements.splice(index, 1);
 
-        this._lockedElementCache = [];
-        this._unlockedElementCache = [];
-
         if (this._lockingElements.length === 0) {
           this._unlockScrollInteractions();
         }
       },
 
       _lockingElements: [],
-
-      _lockedElementCache: null,
-
-      _unlockedElementCache: null,
 
       _originalBodyStyles: {},
 
@@ -133,78 +135,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           event, 'pageup pagedown home end up left down right');
       },
 
-      _hasCachedLockedElement: function(element) {
-        return this._lockedElementCache.indexOf(element) > -1;
-      },
-
-      _hasCachedUnlockedElement: function(element) {
-        return this._unlockedElementCache.indexOf(element) > -1;
-      },
-
-      _composedTreeContains: function(element, child) {
-        // NOTE(cdata): This method iterates over content elements and their
-        // corresponding distributed nodes to implement a contains-like method
-        // that pierces through the composed tree of the ShadowDOM. Results of
-        // this operation are cached (elsewhere) on a per-scroll-lock basis, to
-        // guard against potentially expensive lookups happening repeatedly as
-        // a user scrolls / touchmoves.
-        var contentElements;
-        var distributedNodes;
-        var contentIndex;
-        var nodeIndex;
-
-        if (element.contains(child)) {
-          return true;
-        }
-
-        contentElements = Polymer.dom(element).querySelectorAll('content');
-
-        for (contentIndex = 0; contentIndex < contentElements.length; ++contentIndex) {
-
-          distributedNodes = Polymer.dom(contentElements[contentIndex]).getDistributedNodes();
-
-          for (nodeIndex = 0; nodeIndex < distributedNodes.length; ++nodeIndex) {
-
-            if (this._composedTreeContains(distributedNodes[nodeIndex], child)) {
-              return true;
-            }
-          }
-        }
-
-        return false;
-      },
-
       _scrollInteractionHandler: function(event) {
-        var scrolledElement =
-            /** @type {HTMLElement} */(Polymer.dom(event).rootTarget);
-        if (Polymer
-              .IronDropdownScrollManager
-              .elementIsScrollLocked(scrolledElement)) {
-          if (event.type === 'keydown' &&
-              !Polymer.IronDropdownScrollManager._isScrollingKeypress(event)) {
-            return;
-          }
-
+        if (Polymer.IronDropdownScrollManager.shouldPreventScrolling(event)) {
           event.preventDefault();
         }
+        lastTouch = event;
       },
 
       _lockScrollInteractions: function() {
-        // Memoize body inline styles:
-        this._originalBodyStyles.overflow = document.body.style.overflow;
-        this._originalBodyStyles.overflowX = document.body.style.overflowX;
-        this._originalBodyStyles.overflowY = document.body.style.overflowY;
-
-        // Disable overflow scrolling on body:
-        // TODO(cdata): It is technically not sufficient to hide overflow on
-        // body alone. A better solution might be to traverse all ancestors of
-        // the current scroll locking element and hide overflow on them. This
-        // becomes expensive, though, as it would have to be redone every time
-        // a new scroll locking element is added.
-        document.body.style.overflow = 'hidden';
-        document.body.style.overflowX = 'hidden';
-        document.body.style.overflowY = 'hidden';
-
         // Modern `wheel` event for mouse wheel scrolling:
         document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
@@ -218,10 +156,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _unlockScrollInteractions: function() {
-        document.body.style.overflow = this._originalBodyStyles.overflow;
-        document.body.style.overflowX = this._originalBodyStyles.overflowX;
-        document.body.style.overflowY = this._originalBodyStyles.overflowY;
-
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
@@ -230,4 +164,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     };
   })();
+
 </script>

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -43,8 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       shouldPreventScrolling: function(event) {
         // Avoid expensive checks if the event is not one of the observed keys.
-        if (event.type === 'keydown' && !this._isScrollingKeypress(event)) {
-          return false;
+        if (event.type === 'keydown') {
+          // Prevent event if it is one of the scrolling keys.
+          return this._isScrollingKeypress(event);
         }
 
         var lockingElement = this.currentLockingElement;
@@ -130,8 +131,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _lockingElements: [],
-
-      _originalBodyStyles: {},
 
       _isScrollingKeypress: function(event) {
         return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -49,35 +49,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         var currentLockingElement = this.currentLockingElement;
-        if (currentLockingElement === undefined)
+        if (currentLockingElement === undefined) {
           return false;
+        }
+
+        var xDelta = event.wheelDeltaX;
+        var yDelta = event.wheelDeltaY;
+        if (event.type === 'touchmove' && lastTouch) {
+          xDelta = lastTouch.pageX - event.pageX;
+          yDelta = event.pageY - lastTouch.pageY;
+        }
 
         var nodes = Polymer.dom(event).path;
         var lockingIndex = nodes.indexOf(currentLockingElement);
-        var isScrollingRight = event.wheelDeltaX > 0;
-        var isScrollingUp = event.wheelDeltaY > 0;
-        if (event.type === 'touchmove' && lastTouch) {
-          isScrollingUp = event.pageY > lastTouch.pageY;
-          isScrollingRight = lastTouch.pageX > event.pageX;
-        }
         // Search for one scrollable that can still scroll, stop at the locked element.
         for (var i = 0; i < lockingIndex; i++) {
           var node = nodes[i];
-          // Skip nodes that are not scrollable.
-          if (node.scrollHeight <= node.clientHeight && node.scrollWidth <= node.clientWidth) {
-            continue;
+
+          // Check either vertical or horizontal, according to where
+          // there was more scroll.
+          var scrollDelta, scrollableSize, scrollPos;
+          if (Math.abs(yDelta) >= Math.abs(xDelta)) {
+            scrollDelta = yDelta;
+            scrollableSize = node.scrollHeight - node.clientHeight;
+            scrollPos = node.scrollTop;
+          } else {
+            scrollDelta = xDelta;
+            scrollableSize = node.scrollWidth - node.clientWidth;
+            scrollPos = node.scrollLeft;
           }
-          var canScrollVertically = isScrollingUp ? node.scrollTop > 0 :
-              node.scrollTop + node.clientHeight < node.scrollHeight;
-          var canScrollHorizontally = isScrollingRight ? node.scrollLeft > 0 :
-              node.scrollLeft + node.clientWidth < node.scrollWidth;
           // If it can scroll, don't prevent.
-          if (canScrollVertically || canScrollHorizontally) {
+          if (scrollDelta !== 0 && scrollableSize > 0 &&
+              (scrollDelta > 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
             return false;
           }
         }
         // Don't prevent if event's target is currentLockingElement.
-        return (lockingIndex !== 0);
+        return lockingIndex !== 0;
       },
 
       /**

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -23,7 +23,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * allowed to scroll.
      */
 
-
     Polymer.IronDropdownScrollManager = {
 
       /**
@@ -151,6 +150,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _lockScrollInteractions: function() {
+        // Memoize body scroll position
+        this._saveScrollPosition();
+        document.addEventListener('scroll', this._restoreScrollPosition, true);
+
         // Modern `wheel` event for mouse wheel scrolling:
         document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
@@ -164,11 +167,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _unlockScrollInteractions: function() {
+        document.removeEventListener('scroll', this._restoreScrollPosition, true);
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
+      },
+
+      /**
+       * Memoizes the scroll position of the outside scrolling element.
+       * @private
+       */
+      _saveScrollPosition: function() {
+        if (document.scrollingElement) {
+          this._scrollTop = document.scrollingElement.scrollTop;
+          this._scrollLeft = document.scrollingElement.scrollLeft;
+        } else {
+          // Since we don't know if is the body or html, get max.
+          this._scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+          this._scrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
+        }
+      },
+
+      /**
+       * Resets the scroll position of the outside scrolling element.
+       * @private
+       */
+      _restoreScrollPosition: function() {
+        if (document.scrollingElement) {
+          document.scrollingElement.scrollTop = this._scrollTop;
+          document.scrollingElement.scrollLeft = this._scrollLeft;
+        } else {
+          // Since we don't know if is the body or html, set both.
+          document.documentElement.scrollTop = this._scrollTop;
+          document.documentElement.scrollLeft = this._scrollLeft;
+          document.body.scrollTop = this._scrollTop;
+          document.body.scrollLeft = this._scrollLeft;
+        }
       }
     };
   })();

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -47,39 +47,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return false;
         }
 
-        var currentLockingElement = this.currentLockingElement;
-        if (currentLockingElement === undefined) {
+        var lockingElement = this.currentLockingElement;
+        if (!lockingElement) {
           return false;
         }
 
-        var xDelta = event.wheelDeltaX;
-        var yDelta = event.wheelDeltaY;
-        if (event.type === 'touchmove' && lastTouch) {
-          xDelta = lastTouch.pageX - event.pageX;
-          yDelta = event.pageY - lastTouch.pageY;
-        }
+        // Makes sure deltaX/Y are set.
+        this._normalizeWheelDelta(event);
 
-        var nodes = Polymer.dom(event).path;
-        var lockingIndex = nodes.indexOf(currentLockingElement);
+        var eventPath = Polymer.dom(event).path;
+        var lockingIndex = eventPath.indexOf(lockingElement);
         // Search for one scrollable that can still scroll, stop at the locked element.
         for (var i = 0; i < lockingIndex; i++) {
-          var node = nodes[i];
+          var node = eventPath[i];
 
           // Check either vertical or horizontal, according to where
           // there was more scroll.
           var scrollDelta, scrollableSize, scrollPos;
-          if (Math.abs(yDelta) >= Math.abs(xDelta)) {
-            scrollDelta = yDelta;
+          if (Math.abs(event.deltaY) >= Math.abs(event.deltaX)) {
+            scrollDelta = event.deltaY;
             scrollableSize = node.scrollHeight - node.clientHeight;
             scrollPos = node.scrollTop;
           } else {
-            scrollDelta = xDelta;
+            scrollDelta = event.deltaX;
             scrollableSize = node.scrollWidth - node.clientWidth;
             scrollPos = node.scrollLeft;
           }
           // If it can scroll, don't prevent.
           if (scrollDelta !== 0 && scrollableSize > 0 &&
-              (scrollDelta > 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
+            (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
             return false;
           }
         }
@@ -168,8 +164,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
+      },
+
+      /**
+       * Normalizes `deltaX` and `deltaY` of the wheel event.
+       * Positive value: scroll down/right
+       * Negative value: scroll up/left.
+       * @private
+       */
+      _normalizeWheelDelta: function(event) {
+        // Already set, return.
+        if (event.deltaX || event.deltaY) {
+          return;
+        }
+        // Safari has scroll info in `wheelDeltaX/Y`.
+        if (event.wheelDeltaX || event.wheelDeltaY) {
+          event.deltaX = -event.wheelDeltaX;
+          event.deltaY = -event.wheelDeltaY;
+        }
+        // Firefox has scroll info in `detail` and `axis`.
+        else if (event.axis) {
+          event.deltaX = event.axis === 1 ? event.detail : 0;
+          event.deltaY = event.axis === 2 ? event.detail : 0;
+        }
+        // Mobile devices, must calculate the scroll direction.
+        else if (event.type === 'touchmove' && lastTouch) {
+          event.deltaX = event.pageX - lastTouch.pageX;
+          event.deltaY = lastTouch.pageY - event.pageY;
+        }
       }
     };
   })();
-
 </script>

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -15,7 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
     // Used to calculate the scroll direction.
-    var lastTouch = null;
+    var PREV_EVENT = null;
+    var EVENT_PATH = [];
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
@@ -35,8 +36,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
       /**
-       * Returns true if the element causing the scroll is "scroll locked," which is to
-       * say that it cannot be scrolled via pointer or keyboard interactions, or
+       * Returns true if the element causing the scroll is "scroll locked",
+       * meaning it cannot be scrolled via pointer or keyboard interactions, or
        * if already at its scroll boundaries.
        *
        * @param {Event} event The scroll event
@@ -55,32 +56,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Makes sure deltaX/Y are set.
         this._normalizeWheelDelta(event);
+        // No scrolling.
+        if (!event.deltaX && !event.deltaY) {
+          return false;
+        }
+        // Check either vertical or horizontal, according to where
+        // there was more scroll.
+        var scrollDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ?
+          event.deltaY : event.deltaX;
 
-        var eventPath = Polymer.dom(event).path;
-        var lockingIndex = eventPath.indexOf(lockingElement);
+        // Check if EVENT_PATH needs to be updated. For touch events rely on the
+        // `EVENT_PATH` saved on touchstart.
+        if (event.type !== 'touchmove') {
+          EVENT_PATH = Polymer.dom(event).path;
+        }
+        var lockingIndex = EVENT_PATH.indexOf(lockingElement);
         // Search for one scrollable that can still scroll, stop at the locked element.
         for (var i = 0; i < lockingIndex; i++) {
-          var node = eventPath[i];
-
-          // Check either vertical or horizontal, according to where
-          // there was more scroll.
-          var scrollDelta, scrollableSize, scrollPos;
-          if (Math.abs(event.deltaY) >= Math.abs(event.deltaX)) {
-            scrollDelta = event.deltaY;
-            scrollableSize = node.scrollHeight - node.clientHeight;
-            scrollPos = node.scrollTop;
-          } else {
-            scrollDelta = event.deltaX;
-            scrollableSize = node.scrollWidth - node.clientWidth;
-            scrollPos = node.scrollLeft;
-          }
+          var node = EVENT_PATH[i];
+          var scrollableSize = scrollDelta === event.deltaY ?
+            node.scrollHeight - node.clientHeight : node.scrollWidth - node.clientWidth;
+          var scrollPos = scrollDelta === event.deltaY ? node.scrollTop : node.scrollLeft;
           // If it can scroll, don't prevent.
-          if (scrollDelta !== 0 && scrollableSize > 0 &&
-            (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
+          if (scrollableSize > 0 && (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
             return false;
           }
         }
-        // Don't prevent if event's target is currentLockingElement.
+        // Don't prevent if event's target is the current locking element.
         return lockingIndex !== 0;
       },
 
@@ -132,6 +134,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _lockingElements: [],
 
+      _touchstartHandler: function(event) {
+        // Memoize it, since on mobile the scroll gesture might happen outside
+        // the element initially touched.
+        EVENT_PATH = Polymer.dom(event).path;
+      },
+
       _isScrollingKeypress: function(event) {
         return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(
           event, 'pageup pagedown home end up left down right');
@@ -141,7 +149,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (Polymer.IronDropdownScrollManager.shouldPreventScrolling(event)) {
           event.preventDefault();
         }
-        lastTouch = event;
+        PREV_EVENT = event;
       },
 
       _lockScrollInteractions: function() {
@@ -151,6 +159,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.addEventListener('mousewheel', this._scrollInteractionHandler, true);
         // IE:
         document.addEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
+        // Save the EVENT_PATH on touchstart, to be used on touchmove.
+        document.addEventListener('touchstart', this._touchstartHandler, true);
         // Mobile devices can scroll on touch move:
         document.addEventListener('touchmove', this._scrollInteractionHandler, true);
         // Capture keydown to prevent scrolling keys (pageup, pagedown etc.)
@@ -161,6 +171,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
+        document.removeEventListener('touchstart', this._touchstartHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
       },
@@ -187,9 +198,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           event.deltaY = event.axis === 2 ? event.detail : 0;
         }
         // Mobile devices, must calculate the scroll direction.
-        else if (event.type === 'touchmove' && lastTouch) {
-          event.deltaX = event.pageX - lastTouch.pageX;
-          event.deltaY = lastTouch.pageY - event.pageY;
+        else if (event.type === 'touchmove' && PREV_EVENT) {
+          event.deltaX = event.pageX - PREV_EVENT.pageX;
+          event.deltaY = PREV_EVENT.pageY - event.pageY;
         }
       }
     };

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -150,10 +150,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _lockScrollInteractions: function() {
-        // Memoize body scroll position
-        this._saveScrollPosition();
-        document.addEventListener('scroll', this._restoreScrollPosition, true);
-
         // Modern `wheel` event for mouse wheel scrolling:
         document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
@@ -167,44 +163,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _unlockScrollInteractions: function() {
-        document.removeEventListener('scroll', this._restoreScrollPosition, true);
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
-      },
-
-      /**
-       * Memoizes the scroll position of the outside scrolling element.
-       * @private
-       */
-      _saveScrollPosition: function() {
-        if (document.scrollingElement) {
-          this._scrollTop = document.scrollingElement.scrollTop;
-          this._scrollLeft = document.scrollingElement.scrollLeft;
-        } else {
-          // Since we don't know if is the body or html, get max.
-          this._scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
-          this._scrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
-        }
-      },
-
-      /**
-       * Resets the scroll position of the outside scrolling element.
-       * @private
-       */
-      _restoreScrollPosition: function() {
-        if (document.scrollingElement) {
-          document.scrollingElement.scrollTop = this._scrollTop;
-          document.scrollingElement.scrollLeft = this._scrollLeft;
-        } else {
-          // Since we don't know if is the body or html, set both.
-          document.documentElement.scrollTop = this._scrollTop;
-          document.documentElement.scrollLeft = this._scrollLeft;
-          document.body.scrollTop = this._scrollTop;
-          document.body.scrollLeft = this._scrollLeft;
-        }
       }
     };
   })();

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -143,6 +143,18 @@ method is called on the element.
           allowOutsideScroll: {
             type: Boolean,
             value: false
+          },
+
+          /**
+           * Callback for scroll events.
+           * @type {Function}
+           * @private
+           */
+          _boundOnCaptureScroll: {
+            type: Function,
+            value: function() {
+              return this._onCaptureScroll.bind(this);
+            }
           }
         },
 
@@ -169,6 +181,14 @@ method is called on the element.
           return this.focusTarget || this.containedElement;
         },
 
+        ready: function() {
+          // Memoized scrolling position, used to block scrolling outside.
+          this._scrollTop = 0;
+          this._scrollLeft = 0;
+          // Used to perform a non-blocking refit on scroll.
+          this._refitOnScrollRAF = null;
+        },
+
         detached: function() {
           this.cancelAnimation();
           Polymer.IronDropdownScrollManager.removeScrollLock(this);
@@ -185,9 +205,12 @@ method is called on the element.
             this.cancelAnimation();
             this.sizingTarget = this.containedElement || this.sizingTarget;
             this._updateAnimationConfig();
-            if (this.opened && !this.allowOutsideScroll) {
-              Polymer.IronDropdownScrollManager.pushScrollLock(this);
+            this._saveScrollPosition();
+            if (this.opened) {
+              document.addEventListener('scroll', this._boundOnCaptureScroll);
+              !this.allowOutsideScroll && Polymer.IronDropdownScrollManager.pushScrollLock(this);
             } else {
+              document.removeEventListener('scroll', this._boundOnCaptureScroll);
               Polymer.IronDropdownScrollManager.removeScrollLock(this);
             }
             Polymer.IronOverlayBehaviorImpl._openedChanged.apply(this, arguments);
@@ -210,6 +233,7 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderClosed: function() {
+
           if (!this.noAnimations && this.animationConfig.close) {
             this.$.contentWrapper.classList.add('animating');
             this.playAnimation('close');
@@ -230,6 +254,47 @@ method is called on the element.
             this._finishRenderOpened();
           } else {
             this._finishRenderClosed();
+          }
+        },
+
+        _onCaptureScroll: function() {
+          if (!this.allowOutsideScroll) {
+            this._restoreScrollPosition();
+          } else {
+            this._refitOnScrollRAF && window.cancelAnimationFrame(this._refitOnScrollRAF);
+            this._refitOnScrollRAF = window.requestAnimationFrame(this.refit.bind(this));
+          }
+        },
+
+        /**
+         * Memoizes the scroll position of the outside scrolling element.
+         * @private
+         */
+        _saveScrollPosition: function() {
+          if (document.scrollingElement) {
+            this._scrollTop = document.scrollingElement.scrollTop;
+            this._scrollLeft = document.scrollingElement.scrollLeft;
+          } else {
+            // Since we don't know if is the body or html, get max.
+            this._scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+            this._scrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
+          }
+        },
+
+        /**
+         * Resets the scroll position of the outside scrolling element.
+         * @private
+         */
+        _restoreScrollPosition: function() {
+          if (document.scrollingElement) {
+            document.scrollingElement.scrollTop = this._scrollTop;
+            document.scrollingElement.scrollLeft = this._scrollLeft;
+          } else {
+            // Since we don't know if is the body or html, set both.
+            document.documentElement.scrollTop = this._scrollTop;
+            document.documentElement.scrollLeft = this._scrollLeft;
+            document.body.scrollTop = this._scrollTop;
+            document.body.scrollLeft = this._scrollLeft;
           }
         },
 

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -31,12 +31,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
   <script>
+
+    function fireWheel(node, deltaX, deltaY) {
+      // IE 11 doesn't support WheelEvent, use CustomEvent.
+      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      node.dispatchEvent(event);
+      return event;
+    }
+
     suite('IronDropdownScrollManager', function() {
       var parent;
       var childOne;
       var childTwo;
-      var grandchildOne;
-      var grandchildTwo;
+      var grandChildOne;
+      var grandChildTwo;
       var ancestor;
 
       setup(function() {
@@ -58,57 +66,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childTwo))
-            .to.be.equal(true);
+          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildTwo))
-            .to.be.equal(true);
+          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
-            .to.be.equal(true);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(ancestor))
-            .to.be.equal(true);
+          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childOne))
-            .to.be.equal(false);
+          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildOne))
-            .to.be.equal(false);
+          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
-            .to.be.equal(false);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('does not check locked elements when there are no locking elements', function() {
-          sinon.spy(Polymer.IronDropdownScrollManager, 'elementIsScrollLocked');
-          childOne.dispatchEvent(new CustomEvent('wheel', {
-            bubbles: true,
-            cancelable: true
-          }));
+          sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
-              .elementIsScrollLocked.callCount).to.be.eql(1);
+              .shouldPreventScrolling.callCount).to.be.eql(1);
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          childOne.dispatchEvent(new CustomEvent('wheel', {
-            bubbles: true,
-            cancelable: true
-          }));
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
-              .elementIsScrollLocked.callCount).to.be.eql(1);
+              .shouldPreventScrolling.callCount).to.be.eql(1);
         });
 
         suite('various scroll events', function() {

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -35,8 +35,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
       var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
-      event.wheelDeltaX = deltaX;
-      event.wheelDeltaY = deltaY;
+      event.deltaX = deltaX;
+      event.deltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -68,42 +68,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(fireWheel(childTwo, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(fireWheel(grandChildTwo, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(fireWheel(ancestor, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(fireWheel(childOne, 0, -10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(fireWheel(grandChildOne, 0, -10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('does not check locked elements when there are no locking elements', function() {
           sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
-          fireWheel(childOne, 0, -10);
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          fireWheel(childOne, 0, -10);
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
         });
@@ -125,8 +125,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 bubbles: true,
                 cancelable: true
               });
-              event.wheelDeltaX = 0;
-              event.wheelDeltaY = -10;
+              event.deltaX = 0;
+              event.deltaY = 10;
               return event;
             });
           });

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -34,7 +34,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
+      event.wheelDeltaX = deltaX;
+      event.wheelDeltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -66,42 +68,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(childTwo, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(grandChildTwo, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(ancestor, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(childOne, 0, -10).defaultPrevented).to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(grandChildOne, 0, -10).defaultPrevented).to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(false);
         });
 
         test('does not check locked elements when there are no locking elements', function() {
           sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
-          fireWheel(childOne, 0, 10);
+          fireWheel(childOne, 0, -10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          fireWheel(childOne, 0, 10);
+          fireWheel(childOne, 0, -10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
         });
@@ -119,10 +121,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ];
 
             events = scrollEvents.map(function(scrollEvent) {
-              return new CustomEvent(scrollEvent, {
+              var event = new CustomEvent(scrollEvent, {
                 bubbles: true,
                 cancelable: true
               });
+              event.wheelDeltaX = 0;
+              event.wheelDeltaY = -10;
+              return event;
             });
           });
 

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -157,8 +157,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         cancelable: true,
         bubbles: true
       });
-      event.wheelDeltaX = deltaX;
-      event.wheelDeltaY = deltaY;
+      event.deltaX = deltaX;
+      event.deltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -261,7 +261,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
-            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(true);
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
 
             if (openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
@@ -304,7 +304,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
           runAfterOpen(dropdown, function() {
-            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(false);
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
             done();
           });
         });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -9,6 +9,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>iron-dropdown basic tests</title>
@@ -54,6 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     height: 3000px;
   }
 </style>
+
 <body>
 
   <test-fixture id="TrivialDropdown">
@@ -133,6 +135,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+
   <script>
     function elementIsVisible(element) {
       var contentRect = element.getBoundingClientRect();
@@ -150,11 +153,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
+      var event = new CustomEvent('wheel', {
+        cancelable: true,
+        bubbles: true
+      });
       event.wheelDeltaX = deltaX;
       event.wheelDeltaY = deltaY;
       node.dispatchEvent(event);
       return event;
+    }
+
+    function dispatchScroll(target, scrollLeft, scrollTop) {
+      target.scrollLeft = scrollLeft;
+      target.scrollTop = scrollTop;
+      target.dispatchEvent(new CustomEvent('scroll', { bubbles:true } ));
     }
 
     suite('<iron-dropdown>', function() {
@@ -172,14 +184,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('shows dropdown content when opened', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             expect(elementIsVisible(content)).to.be.equal(true);
             done();
           });
         });
 
         test('hides dropdown content when outside is clicked', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             expect(elementIsVisible(content)).to.be.equal(true);
             dropdown.addEventListener('iron-overlay-closed', function() {
               expect(elementIsVisible(content)).to.be.equal(false);
@@ -195,7 +207,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             content = Polymer.dom(dropdown).querySelector('.dropdown-content');
           });
           test('focuses the content when opened', function(done) {
-            runAfterOpen(dropdown, function () {
+            runAfterOpen(dropdown, function() {
               expect(document.activeElement).to.be.equal(content);
               done();
             });
@@ -205,7 +217,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var focusableChild = Polymer.dom(content).querySelector('div[tabindex]');
             dropdown.focusTarget = focusableChild;
 
-            runAfterOpen(dropdown, function () {
+            runAfterOpen(dropdown, function() {
               expect(document.activeElement).to.not.be.equal(content);
               expect(document.activeElement).to.be.equal(focusableChild);
               done();
@@ -216,8 +228,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('locking scroll', function() {
 
+        var bigDiv, scrollTarget;
+        suiteSetup(function() {
+          bigDiv = document.createElement('div');
+          bigDiv.classList.add('big');
+          document.body.appendChild(bigDiv);
+          // Need to discover if html or body is scrollable.
+          // Here we are sure the page is scrollable.
+          document.documentElement.scrollTop = 1;
+          if (document.documentElement.scrollTop === 1) {
+            document.documentElement.scrollTop = 0;
+            scrollTarget = document.documentElement;
+          } else {
+            scrollTarget = document.body;
+          }
+        });
+
+        suiteTeardown(function() {
+          document.body.removeChild(bigDiv);
+        });
+
         setup(function() {
           dropdown = fixture('TrivialDropdown');
+        });
+
+        teardown(function() {
+          dispatchScroll(scrollTarget, 0, 0);
         });
 
         test('should lock, only once', function(done) {
@@ -227,7 +263,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               .to.be.equal(1);
             expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(true);
 
-            if(openCount === 0) {
+            if (openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
               // that should not add the element to the `_lockingElements` stack twice
               dropdown.close();
@@ -238,6 +274,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             openCount++;
           });
         });
+
+        test('should lock scroll', function(done) {
+          runAfterOpen(dropdown, function() {
+            dispatchScroll(scrollTarget, 10, 10);
+            assert.equal(scrollTarget.scrollTop, 0, 'scrollTop ok');
+            assert.equal(scrollTarget.scrollLeft, 0, 'scrollLeft ok');
+            done();
+          });
+        });
+
+        test('can be disabled with `allowOutsideScroll`', function(done) {
+          dropdown.allowOutsideScroll = true;
+          runAfterOpen(dropdown, function() {
+            dispatchScroll(scrollTarget, 10, 10);
+            assert.equal(scrollTarget.scrollTop, 10, 'scrollTop ok');
+            assert.equal(scrollTarget.scrollLeft, 10, 'scrollLeft ok');
+            done();
+          });
+        });
+
       });
 
       suite('non locking scroll', function() {
@@ -247,7 +303,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(false);
             done();
           });
@@ -265,7 +321,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be re-aligned to the right and the top', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
@@ -278,7 +334,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be re-aligned to the bottom', function(done) {
           dropdown.verticalAlign = 'bottom';
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             parentRect = parent.getBoundingClientRect();
             dropdownRect = dropdown.getBoundingClientRect();
             assert.equal(dropdownRect.top, 0, 'top ok');
@@ -292,7 +348,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('handles parent\'s stacking context', function(done) {
           // This will create a new stacking context.
           parent.style.transform = 'translateZ(0)';
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
@@ -313,7 +369,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the bottom right', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
@@ -329,7 +385,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the top left', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
@@ -354,7 +410,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the top left', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
@@ -370,7 +426,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the bottom right', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
@@ -392,7 +448,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=left', function(done) {
           var parent = fixture('RTLDropdownLeft');
           dropdown = parent.querySelector('iron-dropdown');
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             // In RTL, if `horizontalAlign` is "left", that's the same as
             // being right-aligned in LTR. So the dropdown should be in the top
             // right corner.
@@ -406,7 +462,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=right', function(done) {
           var parent = fixture('RTLDropdownRight');
           dropdown = parent.querySelector('iron-dropdown');
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             // In RTL, if `horizontalAlign` is "right", that's the same as
             // being left-aligned in LTR. So the dropdown should be in the top
             // left corner.
@@ -420,4 +476,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </body>
+
 </html>

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -318,15 +318,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function() {
           parent = fixture('AlignedDropdown');
           dropdown = parent.querySelector('iron-dropdown');
+          parentRect = parent.getBoundingClientRect();
         });
 
         test('can be re-aligned to the right and the top', function(done) {
           runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
-            parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
-            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
+            assert.equal(dropdownRect.bottom, window.innerHeight, 'bottom ok');
             assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });
@@ -335,7 +335,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('can be re-aligned to the bottom', function(done) {
           dropdown.verticalAlign = 'bottom';
           runAfterOpen(dropdown, function() {
-            parentRect = parent.getBoundingClientRect();
             dropdownRect = dropdown.getBoundingClientRect();
             assert.equal(dropdownRect.top, 0, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
@@ -350,10 +349,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           parent.style.transform = 'translateZ(0)';
           runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
-            parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
-            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
+            assert.equal(dropdownRect.bottom, window.innerHeight, 'bottom ok');
             assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -150,7 +150,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
+      event.wheelDeltaX = deltaX;
+      event.wheelDeltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -223,7 +225,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
-            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
+            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(true);
 
             if(openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
@@ -246,7 +248,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
           runAfterOpen(dropdown, function () {
-            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
+            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(false);
             done();
           });
         });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -148,6 +148,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       overlay.open();
     }
 
+    function fireWheel(node, deltaX, deltaY) {
+      // IE 11 doesn't support WheelEvent, use CustomEvent.
+      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      node.dispatchEvent(event);
+      return event;
+    }
+
     suite('<iron-dropdown>', function() {
       var dropdown;
       var content;
@@ -216,8 +223,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
-            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-              .to.be.equal(true);
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
 
             if(openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
@@ -239,9 +245,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
-          runAfterOpen(dropdown, function() {
-            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-              .to.be.equal(false);
+          runAfterOpen(dropdown, function () {
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
             done();
           });
         });

--- a/test/x-scrollable-element.html
+++ b/test/x-scrollable-element.html
@@ -12,11 +12,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="x-scrollable-element">
   <template>
+    <style>
+      :host {
+        display: block;
+        height: 100px;
+        border: 1px solid red;
+        overflow: auto;
+      }
+      #ChildOne, #ChildTwo {
+        height: 200px;
+        border: 1px solid blue;
+        overflow: auto;
+      }
+      #GrandchildOne, #GrandchildTwo {
+        height: 300px;
+        border: 1px solid green;
+        overflow: auto;
+      }
+      .scrollContent {
+        height: 400px;
+        background-color: yellow;
+      }
+    </style>
     <div id="ChildOne">
-      <div id="GrandchildOne"></div>
+      <div id="GrandchildOne">
+        <div class="scrollContent"></div>
+      </div>
     </div>
     <div id="ChildTwo">
-      <div id="GrandchildTwo"></div>
+      <div id="GrandchildTwo">
+        <div class="scrollContent"></div>
+      </div>
     </div>
   </template>
   <script>


### PR DESCRIPTION
Fixes #54 , fixes #43.

For #54, the goal is to keep the overflow on `document.body`, and prevent the scrolling from happening if:
- the scroll happens outside the locked element
- the scroll happens inside the locked element, but the target is contained in scrollable parents that cannot scroll (because they're at their boundaries already)

For #43, the `scroll` event listener on document will restore scrolling if it happens because of a user text selection or if the user scrolls through the side scroll bars. If `allowScrollOutside`, it will call `refit`