### PR TITLE
Support for proper Absolute positioned dropdowns

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -31,6 +31,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       max-width: 250px;
     }
 
+    .absolute-content {
+      width: 250px;
+      padding: 1.5em 2em;
+    }
+
     button {
       border: 1px solid #ccc;
       background-color: #eee;
@@ -123,6 +128,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </ul>
         </x-select>
       </div>
+
+     <p>Examples of absolute positioning</p>
+     <div style="height: 500px">
+       <x-select position="absolute">
+         <button class="dropdown-trigger">Basic</button>
+         <div class="dropdown-content absolute-content">
+           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+         </div>
+       </x-select>
+       <x-select position="absolute" vertical-align="bottom" horizontal-align="left">
+         <button class="dropdown-trigger">Bottom-left aligned</button>
+         <div class="dropdown-content absolute-content">
+           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+         </div>
+       </x-select>
+       <x-select position="absolute" vertical-align="top" horizontal-align="right">
+         <button class="dropdown-trigger">Top-right aligned</button>
+         <div class="dropdown-content absolute-content">
+           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+         </div>
+       </x-select>
+       <x-select horizontal-align="left" vertical-align="top" position="absolute">
+         <button class="dropdown-trigger"> Content</button>
+         <iron-image class="dropdown-content" src="../../iron-image/demo/polymer.svg"></iron-image>
+       </x-select>
+       <x-select horizontal-align="right" vertical-align="top" position="absolute">
+         <button class="dropdown-trigger">Unordered list</button>
+         <ul class="dropdown-content" tabindex="0">
+           <template is="dom-repeat" items="[[dinosaurs]]">
+             <li><a href="javascript:void(0)">[[item]]</a></li>
+           </template>
+         </ul>
+       </x-select>
+       <x-select vertical-align="top" position="absolute" vertical-offset="40">
+         <button class="dropdown-trigger">Vertical Offset</button>
+         <ul class="dropdown-content" tabindex="0">
+           <template is="dom-repeat" items="[[dinosaurs]]">
+             <li><a href="javascript:void(0)">[[item]]</a></li>
+           </template>
+         </ul>
+       </x-select>
+     </div>
     </div>
   </template>
 

--- a/demo/x-select.html
+++ b/demo/x-select.html
@@ -27,6 +27,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
       disabled="[[disabled]]"
+      position="[[position]]"
+      vertical-offset="[[verticalOffset]]"
+      horizontal-offset="[[horizontalOffset]]"
       open-animation-config="[[openAnimationConfig]]"
       close-animation-config="[[closeAnimationConfig]]">
       <content select=".dropdown-content"></content>
@@ -39,7 +42,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       properties: {
         verticalAlign: String,
         horizontalAlign: String,
+        verticalOffset: Number,
+        horizontalOffset: Number,
         disabled: Boolean,
+        position: String,
         openAnimationConfig: {
           type: Array,
           value: function() {
@@ -73,6 +79,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       open: function() {
+        console.log(this.verticalOffset);
+        if (this.position === 'absolute') {
+          this.style.position = 'relative';
+        }
         this.$.dropdown.open();
       }
     });

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -303,7 +303,7 @@ method is called on the element.
 
           target += this.horizontalOffset;
 
-          return Math.max(target, 0);
+          return (this.position === 'absolute' ? target : Math.max(target, 0));
         },
 
         /**

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -99,6 +99,17 @@ method is called on the element.
           },
 
           /**
+           * Positioning of the iron-dropdown. If set to 'absolute' the dropdown will
+           * fit to it's nearest relative parent. If set to 'absolute', the dropdown
+           * will automatically match it's width to the parent object. This can be
+           * overwritten by setting the width of the dropdown content.
+           */
+          position: {
+            type: String,
+            value: 'fixed'
+          },
+
+          /**
            * A pixel value that will be added to the position calculated for the
            * given `horizontalAlign`, in the direction of alignment. You can think
            * of it as increasing or decreasing the distance to the side of the
@@ -213,6 +224,14 @@ method is called on the element.
           if (this.positionTarget === undefined) {
             this.positionTarget = this._defaultPositionTarget;
           }
+
+          // NOTE(jwwisgerhof): When position the iron-dropdown absolutely, the dropdown
+          // should not be forced to fit into the window. Instead, the body should be used.
+          // Auto focus makes no sense for absolute positioned elements, so disable it.
+          if (this.position === 'absolute') {
+            this.fitInto = document.querySelector('body');
+            this.noAutoFocus = true;
+          }
         },
 
         /**
@@ -268,13 +287,18 @@ method is called on the element.
         get _horizontalAlignTargetValue() {
           var target;
 
-          // In RTL, the direction flips, so what is "right" in LTR becomes "left".
-          var isRTL = this._isRTL();
-          if ((!isRTL && this.horizontalAlign === 'right') ||
-              (isRTL && this.horizontalAlign === 'left')) {
-            target = document.documentElement.clientWidth - this._positionRect.right;
+          if (this.position === 'absolute') {
+            // Absolute positioned dropdowns do not need the window offset
+            target = 0;
           } else {
-            target = this._positionRect.left;
+            // In RTL, the direction flips, so what is "right" in LTR becomes "left".
+            var isRTL = this._isRTL();
+            if ((!isRTL && this.horizontalAlign === 'right') ||
+                    (isRTL && this.horizontalAlign === 'left')) {
+              target = document.documentElement.clientWidth - this._positionRect.right;
+            } else {
+              target = this._positionRect.left;
+            }
           }
 
           target += this.horizontalOffset;
@@ -288,10 +312,15 @@ method is called on the element.
         get _verticalAlignTargetValue() {
           var target;
 
-          if (this.verticalAlign === 'bottom') {
-            target = document.documentElement.clientHeight - this._positionRect.bottom;
+          if (this.position === 'absolute') {
+            // Absolute positioned dropdowns do not need the window offset
+            target = 0;
           } else {
-            target = this._positionRect.top;
+            if (this.verticalAlign === 'bottom') {
+              target = document.documentElement.clientHeight - this._positionRect.bottom;
+            } else {
+              target = this._positionRect.top;
+            }
           }
 
           target += this.verticalOffset;
@@ -330,7 +359,7 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderOpened: function() {
-          if (!this.allowOutsideScroll) {
+          if (!this.allowOutsideScroll && this.position !== 'absolute') {
             Polymer.IronDropdownScrollManager.pushScrollLock(this);
           }
 
@@ -454,6 +483,8 @@ method is called on the element.
           if (!this.positionTarget) {
             return;
           }
+
+          this.style.position = this.position;
 
           this.style[this._localeHorizontalAlign] =
             this._horizontalAlignTargetValue + 'px';

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -57,6 +57,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="AbsolutePositioning">
+    <template>
+      <div style="display: block; position: relative; width: 100px; height: 100px;">
+        <iron-dropdown position="absolute">
+          <div class="dropdown-content">Hello!</div>
+        </iron-dropdown>
+      </div>
+    </template>
+  </test-fixture>
+
   <!-- Absolutely position the dropdown so that it has enough space to move around -->
   <test-fixture id="OffsetDropdownTopLeft">
     <template>
@@ -224,6 +234,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
+      });
+
+      suite('absolute positioning', function () {
+        var parent;
+        var dropdown;
+
+        setup(function () {
+          parent = fixture('AbsolutePositioning');
+          dropdown = parent.querySelector('iron-dropdown');
+        });
+
+        test('should overwrite default style rules', function (done) {
+          runAfterOpen(dropdown, function () {
+            expect(dropdown.style.position).to.equal('absolute');
+            expect(dropdown.style.top).to.equal('0px');
+            expect(dropdown.style.left).to.equal('0px');
+            expect(dropdown.$.content.style['max-height']).to.equal('');
+            done();
+          });
+        });
+
+        test('should disable scroll lock', function () {
+          runAfterOpen(dropdown, function () {
+            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
+                    .to.be.equal(false);
+            done();
+          });
+        });
+
+        test('should disable auto focus', function () {
+          expect(dropdown.noAutoFocus).to.equal(true);
+        });
+
+        test('should set the "fitInto" target to be document.body', function () {
+          runAfterOpen(dropdown, function () {
+            expect(dropdown.fitInto).to.be.equal(document.body);
+            done();
+          });
+        })
       });
 
       suite('aligned dropdown', function() {


### PR DESCRIPTION
## The problem

Using iron dropdown for anything but simple dropdowns is nigh on impossible. Hiding the scroll bar causes a bad, and unexpected, user experience. The newly added "allowOutsideScroll" parameter is (in most cases) useless.
## Absolute positioning

Most menus, call outs and tooltips are positioned absolute. By supporting this feature in iron-dropdown, it will become vastly more useful.
## Changes
- Added 4 tests (7 assertions)
- Added 6 demo usecases
- 2 commits (one code, one tests)
## Considerations
- Dropdown must have a 'position: relative' parent. Common sense for everyone working with CSS though
- Absolute positioned items cannot have a dynamic width. A fixed width is required or the dropdown will fit itself to the width of the relative parent.

This fixes #43 by allowing proper absolute positioning instead of a hack work around.
