### PR TITLE
No scroll manager

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -122,6 +122,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             </template>
           </ul>
         </x-select>
+        <x-select allow-outside-scroll style="padding-bottom:90vh">
+          <button class="dropdown-trigger">Allow outside scroll</button>
+          <div class="dropdown-content random-content">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </div>
+        </x-select>
       </div>
     </div>
   </template>

--- a/demo/x-select.html
+++ b/demo/x-select.html
@@ -24,6 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <content select=".dropdown-trigger"></content>
     </div>
     <iron-dropdown id="dropdown"
+      allow-outside-scroll="[[allowOutsideScroll]]"
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
       disabled="[[disabled]]"
@@ -37,6 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'x-select',
 
       properties: {
+        allowOutsideScroll: Boolean,
         verticalAlign: String,
         horizontalAlign: String,
         disabled: Boolean,

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -15,7 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 <link rel="import" href="../neon-animation/neon-animation-runner-behavior.html">
 <link rel="import" href="../neon-animation/animations/opaque-animation.html">
-<link rel="import" href="iron-dropdown-scroll-manager.html">
 
 <!--
 `<iron-dropdown>` is a generalized element that is useful when you have
@@ -188,6 +187,28 @@ method is called on the element.
           allowOutsideScroll: {
             type: Boolean,
             value: false
+          },
+
+          /**
+           * Callback for scroll events.
+           * @type {Function}
+           * @private
+           */
+          _boundOnCaptureScroll: {
+            type: Function,
+            value: function() {
+              return this._onCaptureScroll.bind(this);
+            }
+          },
+
+          /**
+           * The outside scrolling element. Its scrolling will be blocked if `allowOutsideScroll = false`.
+           * @type {Element}
+           * @private
+           */
+          _outsideScrollingElement: {
+            type: Object,
+            value: (document.scrollingElement || document.documentElement)
           }
         },
 
@@ -198,6 +219,14 @@ method is called on the element.
         observers: [
           '_updateOverlayPosition(positionTarget, verticalAlign, horizontalAlign, verticalOffset, horizontalOffset)'
         ],
+
+        ready: function() {
+          // Memoized scrolling position, used to block scrolling outside.
+          this.__outsideScrollTop = 0;
+          this.__outsideScrollLeft = 0;
+          // Used to perform a non-blocking refit on scroll.
+          this.__refitAsync = null;
+        },
 
         attached: function() {
           this.positionTarget = this.positionTarget || this._defaultPositionTarget;
@@ -306,9 +335,8 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderOpened: function() {
-          if (!this.allowOutsideScroll) {
-            Polymer.IronDropdownScrollManager.pushScrollLock(this);
-          }
+          this.__saveScrollOutside();
+          document.addEventListener('scroll', this._boundOnCaptureScroll);
 
           if (!this.noAnimations && this.animationConfig && this.animationConfig.open) {
             if (this.withBackdrop) {
@@ -325,7 +353,7 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderClosed: function() {
-          Polymer.IronDropdownScrollManager.removeScrollLock(this);
+          document.removeEventListener('scroll', this._boundOnCaptureScroll);
           if (!this.noAnimations && this.animationConfig && this.animationConfig.close) {
             if (this.withBackdrop) {
               this.backdropElement.close();
@@ -349,6 +377,47 @@ method is called on the element.
             Polymer.IronOverlayBehaviorImpl._finishRenderOpened.apply(this);
           } else {
             Polymer.IronOverlayBehaviorImpl._finishRenderClosed.apply(this);
+          }
+        },
+
+        _onCaptureScroll: function(event) {
+          if (!this.allowOutsideScroll) {
+            this.__blockScrollOutside();
+          } else if (Polymer.dom(event).path.indexOf(this) === -1) {
+            if (this.__refitAsync) {
+              cancelAnimationFrame(this.__refitAsync);
+            }
+            this.__refitAsync = requestAnimationFrame(this.refit.bind(this));
+          }
+        },
+        /**
+         * Memoizes the scroll position of the outside scrolling element.
+         * @private
+         */
+        __saveScrollOutside: function() {
+          if (document.scrollingElement) {
+            this.__outsideScrollTop = document.scrollingElement.scrollTop;
+            this.__outsideScrollLeft = document.scrollingElement.scrollLeft;
+          } else {
+            // Since we don't know if is the body or html, get max.
+            this.__outsideScrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+            this.__outsideScrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
+          }
+        },
+        /**
+         * Resets the scroll position of the outside scrolling element.
+         * @private
+         */
+        __blockScrollOutside: function() {
+          if (document.scrollingElement) {
+            document.scrollingElement.scrollTop = this.__outsideScrollTop;
+            document.scrollingElement.scrollLeft = this.__outsideScrollLeft;
+          } else {
+            // Since we don't know if is the body or html, set both.
+            document.documentElement.scrollTop = this.__outsideScrollTop;
+            document.documentElement.scrollLeft = this.__outsideScrollLeft;
+            document.body.scrollTop = this.__outsideScrollTop;
+            document.body.scrollLeft = this.__outsideScrollLeft;
           }
         },
 

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -48,7 +48,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     height: 50px;
     background-color: orange;
   }
-  
+
   .full-screen {
     width: 100vw;
     height: 100vh;
@@ -74,9 +74,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="AlignedDropdown">
     <template>
-      <div class="container">
+      <div style="display: block; position: relative; width: 100px; height: 100px;">
         <iron-dropdown horizontal-align="right" vertical-align="top">
-          <div class="dropdown-content full-screen"></div>
+          <div class="dropdown-content">Hello!</div>
+        </iron-dropdown>
+      </div>
+    </template>
+  </test-fixture>
+
+  <!-- Use margin so document.body becomes scrollable vertically & horizontally -->
+  <test-fixture id="ScrollLockDropdown">
+    <template>
+      <div style="position: relative; margin: 90vh;">
+        Scrollable!
+        <iron-dropdown>
+          <div class="dropdown-content">Hello!</div>
         </iron-dropdown>
       </div>
     </template>
@@ -150,6 +162,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       overlay.open();
     }
 
+    function dispatchScroll(target, scrollLeft, scrollTop) {
+      target.scrollLeft = scrollLeft;
+      target.scrollTop = scrollTop;
+      target.dispatchEvent(new CustomEvent('scroll', { bubbles:true } ));
+    }
+
     suite('<iron-dropdown>', function() {
       var dropdown;
       var content;
@@ -208,45 +226,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('locking scroll', function() {
-        var dropdown;
-
+        var parent, scrollTarget;
         setup(function() {
-          dropdown = fixture('TrivialDropdown');
-        });
-
-        test('should lock, only once', function(done) {
-          var openCount = 0;
-          runAfterOpen(dropdown, function() {
-            expect(Polymer.IronDropdownScrollManager._lockingElements.length)
-              .to.be.equal(1);
-            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-              .to.be.equal(true);
-
-            if(openCount === 0) {
-              // This triggers a second `pushScrollLock` with the same element, however
-              // that should not add the element to the `_lockingElements` stack twice
-              dropdown.close();
-              dropdown.open();
+          parent = fixture('ScrollLockDropdown');
+          dropdown = parent.querySelector('iron-dropdown');
+          if (!scrollTarget) {
+            // Need to discover if html or body is scrollable.
+            // Here we are sure the page is scrollable.
+            document.documentElement.scrollTop = 1;
+            if (document.documentElement.scrollTop === 1) {
+              document.documentElement.scrollTop = 0;
+              scrollTarget = document.documentElement;
             } else {
-              done();
+              scrollTarget = document.body;
             }
-            openCount++;
+          }
+        });
+        teardown(function() {
+          dispatchScroll(scrollTarget, 0, 0);
+        });
+        test('should lock scroll', function(done) {
+          runAfterOpen(dropdown, function() {
+            dispatchScroll(scrollTarget, 1, 1);
+            assert.equal(scrollTarget.scrollTop, 0, 'scrollTop ok');
+            assert.equal(scrollTarget.scrollLeft, 0, 'scrollLeft ok');
+            done();
           });
         });
-      });
-
-      suite('non locking scroll', function() {
-        var dropdown;
-
-        setup(function() {
-          dropdown = fixture('NonLockingDropdown');
-        });
-
         test('can be disabled with `allowOutsideScroll`', function(done) {
-          runAfterOpen(dropdown, function () {
-            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-              .to.be.equal(false);
+          dropdown.allowOutsideScroll = true;
+          runAfterOpen(dropdown, function() {
+            dispatchScroll(scrollTarget, 1, 1);
+            assert.equal(scrollTarget.scrollTop, 1, 'scrollTop ok');
+            assert.equal(scrollTarget.scrollLeft, 1, 'scrollLeft ok');
             done();
+          });
+        });
+        test('if disabled, updates position on scroll', function(done) {
+          var dropdownRect, parentRect;
+          dropdown.allowOutsideScroll = true;
+          runAfterOpen(dropdown, function() {
+            dropdownRect = dropdown.getBoundingClientRect();
+            parentRect = parent.getBoundingClientRect();
+            assert.closeTo(dropdownRect.top, parentRect.top, 0.1, 'correct top positioning after opened');
+            assert.closeTo(dropdownRect.left, parentRect.left, 0.1, 'correct left positioning after opened');
+            dispatchScroll(scrollTarget, 10, 10);
+            // Wait for async callback to be performed
+            setTimeout(function() {
+              dropdownRect = dropdown.getBoundingClientRect();
+              parentRect = parent.getBoundingClientRect();
+              assert.closeTo(dropdownRect.top, parentRect.top, 0.1, 'correct top positioning after scroll');
+              assert.closeTo(dropdownRect.left, parentRect.left, 0.1, 'correct left positioning after scroll');
+              done();
+            }, 100);
           });
         });
       });


### PR DESCRIPTION
Fixes #54, fixes #43.
Instead of relying on the ScrollManager to block scrolling outside, we memoize `scrollTop, scrollLeft` when the dropdown is opened and listen for `scroll` event.
We reset the scroll position if `allowScrollOutside` is false (fixes #54 as we don't set `overflow` to `body`);
otherwise we call `refit` if scroll happened outside the dropdown (which fixes #43).

This PR depends on https://github.com/PolymerElements/iron-dropdown/pull/63.
See the last commit to see the changes done for these 2 issues.

Compared to https://github.com/PolymerElements/iron-dropdown/pull/64, this PR uses only one listener, and also handles the case where the scroll is done by dragging the scrollbar.