### PR TITLE
fix tests

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -205,10 +205,6 @@ method is called on the element.
           this.positionTarget = this.positionTarget || this._defaultPositionTarget;
         },
 
-        detached: function() {
-          Polymer.IronDropdownScrollManager.removeScrollLock(this);
-        },
-
         /**
          * The element that is contained by the dropdown, if any.
          */
@@ -301,6 +297,11 @@ method is called on the element.
             this.cancelAnimation();
             this.sizingTarget = this.containedElement || this.sizingTarget;
             this._updateAnimationConfig();
+            if (this.opened && !this.allowOutsideScroll) {
+              Polymer.IronDropdownScrollManager.pushScrollLock(this);
+            } else {
+              Polymer.IronDropdownScrollManager.removeScrollLock(this);
+            }
             Polymer.IronOverlayBehaviorImpl._openedChanged.apply(this, arguments);
           }
         },
@@ -309,10 +310,6 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderOpened: function() {
-          if (!this.allowOutsideScroll) {
-            Polymer.IronDropdownScrollManager.pushScrollLock(this);
-          }
-
           if (!this.noAnimations && this.animationConfig && this.animationConfig.open) {
             if (this.withBackdrop) {
               this.backdropElement.open();
@@ -328,7 +325,6 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderClosed: function() {
-          Polymer.IronDropdownScrollManager.removeScrollLock(this);
           if (!this.noAnimations && this.animationConfig && this.animationConfig.close) {
             if (this.withBackdrop) {
               this.backdropElement.close();

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -200,9 +200,13 @@ method is called on the element.
         ],
 
         attached: function() {
-          this.positionTarget = this.positionTarget || this._defaultPositionTarget;
           // Memoize this to avoid expensive calculations & relayouts.
           this._isRTL = window.getComputedStyle(this).direction == 'rtl';
+          this.positionTarget = this.positionTarget || this._defaultPositionTarget;
+        },
+
+        detached: function() {
+          Polymer.IronDropdownScrollManager.removeScrollLock(this);
         },
 
         /**
@@ -288,11 +292,10 @@ method is called on the element.
 
         /**
          * Called when the value of `opened` changes.
-         *
-         * @param {boolean} opened True if the dropdown is opened.
+         * Overridden from `IronOverlayBehavior`
          */
-        _openedChanged: function(opened) {
-          if (opened && this.disabled) {
+        _openedChanged: function() {
+          if (this.opened && this.disabled) {
             this.cancel();
           } else {
             this.cancelAnimation();

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -27,9 +27,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   body {
     margin: 0;
     padding: 0;
-    /* the scroll manager will disable scrolling when a dropdown is opened, and the scrollbar
-    disappearance will cause wrong bounds calculations. Hence we just disable scrolling in here. */
-    overflow: hidden;
   }
 
   .container {

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -27,6 +27,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   body {
     margin: 0;
     padding: 0;
+    /* the scroll manager will disable scrolling when a dropdown is opened, and the scrollbar
+    disappearance will cause wrong bounds calculations. Hence we just disable scrolling in here. */
+    overflow: hidden;
   }
 
   .container {
@@ -48,10 +51,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     height: 50px;
     background-color: orange;
   }
-  
-  .full-screen {
-    width: 100vw;
-    height: 100vh;
+
+  .big {
+    width: 3000px;
+    height: 3000px;
   }
 </style>
 <body>
@@ -76,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div class="container">
         <iron-dropdown horizontal-align="right" vertical-align="top">
-          <div class="dropdown-content full-screen"></div>
+          <div class="dropdown-content big"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -143,10 +146,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         contentRect.height > 0;
     }
 
-    function runAfterOpen(overlay, cb) {
-      overlay.addEventListener('iron-overlay-opened', function () {
-        Polymer.Base.async(cb, 1);
-      });
+    function runAfterOpen(overlay, callback) {
+      overlay.addEventListener('iron-overlay-opened', callback);
       overlay.open();
     }
 
@@ -174,11 +175,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('hides dropdown content when outside is clicked', function(done) {
           runAfterOpen(dropdown, function () {
             expect(elementIsVisible(content)).to.be.equal(true);
-            MockInteractions.tap(dropdown.parentNode);
-            Polymer.Base.async(function() {
+            dropdown.addEventListener('iron-overlay-closed', function() {
               expect(elementIsVisible(content)).to.be.equal(false);
               done();
-            }, 10);
+            });
+            MockInteractions.tap(dropdown.parentNode);
           });
         });
 
@@ -208,7 +209,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('locking scroll', function() {
-        var dropdown;
 
         setup(function() {
           dropdown = fixture('TrivialDropdown');
@@ -236,14 +236,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('non locking scroll', function() {
-        var dropdown;
 
         setup(function() {
           dropdown = fixture('NonLockingDropdown');
         });
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
               .to.be.equal(false);
             done();
@@ -253,15 +252,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('aligned dropdown', function() {
         var parent;
+        var parentRect;
+        var dropdownRect;
+
         setup(function() {
           parent = fixture('AlignedDropdown');
           dropdown = parent.querySelector('iron-dropdown');
         });
 
         test('can be re-aligned to the right and the top', function(done) {
-          var parentRect;
-          var dropdownRect;
-
           runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
             parentRect = parent.getBoundingClientRect();
@@ -274,9 +273,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be re-aligned to the bottom', function(done) {
-          var parentRect;
-          var dropdownRect;
-
           dropdown.verticalAlign = 'bottom';
           runAfterOpen(dropdown, function () {
             parentRect = parent.getBoundingClientRect();
@@ -290,8 +286,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('handles parent\'s stacking context', function(done) {
-          var parentRect;
-          var dropdownRect;
           // This will create a new stacking context.
           parent.style.transform = 'translateZ(0)';
           runAfterOpen(dropdown, function () {
@@ -309,7 +303,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('when align is left/top, with an offset', function() {
         var dropdownRect;
         var offsetDropdownRect;
-        var dropdown;
         setup(function() {
           var parent = fixture('OffsetDropdownTopLeft');
           dropdown = parent.querySelector('iron-dropdown');
@@ -318,11 +311,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('can be offset towards the bottom right', function(done) {
           runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
-
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
+            // Force refit instead of waiting for requestAnimationFrame.
+            dropdown.refit();
             offsetDropdownRect = dropdown.getBoundingClientRect();
-
             // verticalAlign is top, so a positive offset moves down.
             assert.equal(dropdownRect.top + 10, offsetDropdownRect.top, 'top ok');
             // horizontalAlign is left, so a positive offset moves to the right.
@@ -334,11 +327,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('can be offset towards the top left', function(done) {
           runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
-
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
+            // Force refit instead of waiting for requestAnimationFrame.
+            dropdown.refit();
             offsetDropdownRect = dropdown.getBoundingClientRect();
-
             // verticalAlign is top, so a negative offset moves up.
             assert.equal(dropdownRect.top - 10, offsetDropdownRect.top, 'top ok');
             // horizontalAlign is left, so a negative offset moves to the left.
@@ -351,7 +344,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('when align is right/bottom, with an offset', function() {
         var dropdownRect;
         var offsetDropdownRect;
-        var dropdown;
         setup(function() {
           var parent = fixture('OffsetDropdownBottomRight');
           dropdown = parent.querySelector('iron-dropdown');
@@ -360,11 +352,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('can be offset towards the top left', function(done) {
           runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
-
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
+            // Force refit instead of waiting for requestAnimationFrame.
+            dropdown.refit();
             offsetDropdownRect = dropdown.getBoundingClientRect();
-
             // verticalAlign is bottom, so a positive offset moves up.
             assert.equal(dropdownRect.bottom - 10, offsetDropdownRect.bottom, 'bottom ok');
             // horizontalAlign is right, so a positive offset moves to the left.
@@ -376,11 +368,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('can be offset towards the bottom right', function(done) {
           runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
-
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
+            // Force refit instead of waiting for requestAnimationFrame.
+            dropdown.refit();
             offsetDropdownRect = dropdown.getBoundingClientRect();
-
             // verticalAlign is bottom, so a negative offset moves down.
             assert.equal(dropdownRect.bottom + 10, offsetDropdownRect.bottom, 'bottom ok');
             // horizontalAlign is right, so a positive offset moves to the right.
@@ -391,7 +383,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('RTL', function() {
-        var dropdown;
         var dropdownRect;
 
         test('with horizontalAlign=left', function(done) {


### PR DESCRIPTION
Fixes tests failing on master.
Currently (on master), `iron-overlay-behavior` refits on `_prepareRenderOpened`, and then `iron-dropdown` locks the scroll on `_renderOpened`, which causes the scrollbars to be hidden (hence an offset of ~15px).
To fix this, I moved the push/remove scroll lock in `_openedChanged`, before calling the `iron-overlay-behavior`'s `_openedChanged`