### PR TITLE
reset other 2 dimensions on resetFit

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -429,6 +429,10 @@ method is called on the element.
           // Set to 0, 0 in order to discover any offset caused by parent stacking contexts.
           this.style[hAlign] = this.style[vAlign] = '0px';
 
+          // Reset the other 2 dimensions
+          this.style[hAlign === 'left' ? 'right' : 'left'] = 'auto';
+          this.style[vAlign === 'top' ? 'bottom' : 'top'] = 'auto';
+
           var dropdownRect = this.getBoundingClientRect();
           var positionRect = this.positionTarget.getBoundingClientRect();
           var horizontalValue = this._horizontalAlignTargetValue(dropdownRect, positionRect, hAlign === 'right');

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -282,6 +282,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('can be re-aligned while open', function(done) {
+          runAfterOpen(dropdown, function () {
+            dropdown.verticalAlign = 'bottom';
+            // Force refit instead of waiting for requestAnimationFrame.
+            dropdown.refit();
+            parentRect = parent.getBoundingClientRect();
+            dropdownRect = dropdown.getBoundingClientRect();
+            assert.equal(dropdownRect.top, 0, '1st update, top ok');
+            assert.equal(dropdownRect.left, 0, '1st update, left ok');
+            assert.equal(dropdownRect.bottom, parentRect.bottom, '1st update, bottom ok');
+            assert.equal(dropdownRect.right, parentRect.right, '1st update, right ok');
+
+            // Setting it to the previous value should update it properly.
+            dropdown.verticalAlign = 'top';
+            // Force refit instead of waiting for requestAnimationFrame.
+            dropdown.refit();
+            parentRect = parent.getBoundingClientRect();
+            dropdownRect = dropdown.getBoundingClientRect();
+            assert.equal(dropdownRect.top, parentRect.top, '2nd update, top ok');
+            assert.equal(dropdownRect.left, 0, '2nd update, left ok');
+            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, '2nd update, bottom ok');
+            assert.equal(dropdownRect.right, parentRect.right, '2nd update, right ok');
+            done();
+          });
+        });
+
         test('handles parent\'s stacking context', function(done) {
           // This will create a new stacking context.
           parent.style.transform = 'translateZ(0)';
@@ -295,6 +321,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
+
       });
 
       suite('when align is left/top, with an offset', function() {


### PR DESCRIPTION
Fixes #74 by resetting also the other 2 dimensions on `resetFit`, so that `top, left, bottom, right` have the correct value.