### PR TITLE
Revert "keep overflow, calculate scroll size"

### DIFF
--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -14,9 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   (function() {
     'use strict';
-    // Used to calculate the scroll direction.
-    var PREV_EVENT = null;
-    var EVENT_PATH = [];
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
@@ -36,54 +33,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
       /**
-       * Returns true if the element causing the scroll is "scroll locked",
-       * meaning it cannot be scrolled via pointer or keyboard interactions, or
-       * if already at its scroll boundaries.
+       * Returns true if the provided element is "scroll locked," which is to
+       * say that it cannot be scrolled via pointer or keyboard interactions.
        *
-       * @param {Event} event The scroll event
+       * @param {HTMLElement} element An HTML element instance which may or may
+       * not be scroll locked.
        */
-      shouldPreventScrolling: function(event) {
-        // Avoid expensive checks if the event is not one of the observed keys.
-        if (event.type === 'keydown') {
-          // Prevent event if it is one of the scrolling keys.
-          return this._isScrollingKeypress(event);
+      elementIsScrollLocked: function(element) {
+        var currentLockingElement = this.currentLockingElement;
+
+        if (currentLockingElement === undefined)
+          return false;
+
+        var scrollLocked;
+
+        if (this._hasCachedLockedElement(element)) {
+          return true;
         }
 
-        var lockingElement = this.currentLockingElement;
-        if (!lockingElement) {
+        if (this._hasCachedUnlockedElement(element)) {
           return false;
         }
 
-        // Makes sure deltaX/Y are set.
-        this._normalizeWheelDelta(event);
-        // No scrolling.
-        if (!event.deltaX && !event.deltaY) {
-          return false;
-        }
-        // Check either vertical or horizontal, according to where
-        // there was more scroll.
-        var scrollDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ?
-          event.deltaY : event.deltaX;
+        scrollLocked = !!currentLockingElement &&
+          currentLockingElement !== element &&
+          !this._composedTreeContains(currentLockingElement, element);
 
-        // Check if EVENT_PATH needs to be updated. For touch events rely on the
-        // `EVENT_PATH` saved on touchstart.
-        if (event.type !== 'touchmove') {
-          EVENT_PATH = Polymer.dom(event).path;
+        if (scrollLocked) {
+          this._lockedElementCache.push(element);
+        } else {
+          this._unlockedElementCache.push(element);
         }
-        var lockingIndex = EVENT_PATH.indexOf(lockingElement);
-        // Search for one scrollable that can still scroll, stop at the locked element.
-        for (var i = 0; i < lockingIndex; i++) {
-          var node = EVENT_PATH[i];
-          var scrollableSize = scrollDelta === event.deltaY ?
-            node.scrollHeight - node.clientHeight : node.scrollWidth - node.clientWidth;
-          var scrollPos = scrollDelta === event.deltaY ? node.scrollTop : node.scrollLeft;
-          // If it can scroll, don't prevent.
-          if (scrollableSize > 0 && (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
-            return false;
-          }
-        }
-        // Don't prevent if event's target is the current locking element.
-        return lockingIndex !== 0;
+
+        return scrollLocked;
       },
 
       /**
@@ -107,6 +89,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         this._lockingElements.push(element);
+
+        this._lockedElementCache = [];
+        this._unlockedElementCache = [];
       },
 
       /**
@@ -127,6 +112,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         this._lockingElements.splice(index, 1);
 
+        this._lockedElementCache = [];
+        this._unlockedElementCache = [];
+
         if (this._lockingElements.length === 0) {
           this._unlockScrollInteractions();
         }
@@ -134,33 +122,95 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _lockingElements: [],
 
-      _touchstartHandler: function(event) {
-        // Memoize it, since on mobile the scroll gesture might happen outside
-        // the element initially touched.
-        EVENT_PATH = Polymer.dom(event).path;
-      },
+      _lockedElementCache: null,
+
+      _unlockedElementCache: null,
+
+      _originalBodyStyles: {},
 
       _isScrollingKeypress: function(event) {
         return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(
           event, 'pageup pagedown home end up left down right');
       },
 
+      _hasCachedLockedElement: function(element) {
+        return this._lockedElementCache.indexOf(element) > -1;
+      },
+
+      _hasCachedUnlockedElement: function(element) {
+        return this._unlockedElementCache.indexOf(element) > -1;
+      },
+
+      _composedTreeContains: function(element, child) {
+        // NOTE(cdata): This method iterates over content elements and their
+        // corresponding distributed nodes to implement a contains-like method
+        // that pierces through the composed tree of the ShadowDOM. Results of
+        // this operation are cached (elsewhere) on a per-scroll-lock basis, to
+        // guard against potentially expensive lookups happening repeatedly as
+        // a user scrolls / touchmoves.
+        var contentElements;
+        var distributedNodes;
+        var contentIndex;
+        var nodeIndex;
+
+        if (element.contains(child)) {
+          return true;
+        }
+
+        contentElements = Polymer.dom(element).querySelectorAll('content');
+
+        for (contentIndex = 0; contentIndex < contentElements.length; ++contentIndex) {
+
+          distributedNodes = Polymer.dom(contentElements[contentIndex]).getDistributedNodes();
+
+          for (nodeIndex = 0; nodeIndex < distributedNodes.length; ++nodeIndex) {
+
+            if (this._composedTreeContains(distributedNodes[nodeIndex], child)) {
+              return true;
+            }
+          }
+        }
+
+        return false;
+      },
+
       _scrollInteractionHandler: function(event) {
-        if (Polymer.IronDropdownScrollManager.shouldPreventScrolling(event)) {
+        var scrolledElement =
+            /** @type {HTMLElement} */(Polymer.dom(event).rootTarget);
+        if (Polymer
+              .IronDropdownScrollManager
+              .elementIsScrollLocked(scrolledElement)) {
+          if (event.type === 'keydown' &&
+              !Polymer.IronDropdownScrollManager._isScrollingKeypress(event)) {
+            return;
+          }
+
           event.preventDefault();
         }
-        PREV_EVENT = event;
       },
 
       _lockScrollInteractions: function() {
+        // Memoize body inline styles:
+        this._originalBodyStyles.overflow = document.body.style.overflow;
+        this._originalBodyStyles.overflowX = document.body.style.overflowX;
+        this._originalBodyStyles.overflowY = document.body.style.overflowY;
+
+        // Disable overflow scrolling on body:
+        // TODO(cdata): It is technically not sufficient to hide overflow on
+        // body alone. A better solution might be to traverse all ancestors of
+        // the current scroll locking element and hide overflow on them. This
+        // becomes expensive, though, as it would have to be redone every time
+        // a new scroll locking element is added.
+        document.body.style.overflow = 'hidden';
+        document.body.style.overflowX = 'hidden';
+        document.body.style.overflowY = 'hidden';
+
         // Modern `wheel` event for mouse wheel scrolling:
         document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
         document.addEventListener('mousewheel', this._scrollInteractionHandler, true);
         // IE:
         document.addEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
-        // Save the EVENT_PATH on touchstart, to be used on touchmove.
-        document.addEventListener('touchstart', this._touchstartHandler, true);
         // Mobile devices can scroll on touch move:
         document.addEventListener('touchmove', this._scrollInteractionHandler, true);
         // Capture keydown to prevent scrolling keys (pageup, pagedown etc.)
@@ -168,40 +218,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _unlockScrollInteractions: function() {
+        document.body.style.overflow = this._originalBodyStyles.overflow;
+        document.body.style.overflowX = this._originalBodyStyles.overflowX;
+        document.body.style.overflowY = this._originalBodyStyles.overflowY;
+
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
-        document.removeEventListener('touchstart', this._touchstartHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
-      },
-
-      /**
-       * Normalizes `deltaX` and `deltaY` of the wheel event.
-       * Positive value: scroll down/right
-       * Negative value: scroll up/left.
-       * @private
-       */
-      _normalizeWheelDelta: function(event) {
-        // Already set, return.
-        if (event.deltaX || event.deltaY) {
-          return;
-        }
-        // Safari has scroll info in `wheelDeltaX/Y`.
-        if (event.wheelDeltaX || event.wheelDeltaY) {
-          event.deltaX = -event.wheelDeltaX;
-          event.deltaY = -event.wheelDeltaY;
-        }
-        // Firefox has scroll info in `detail` and `axis`.
-        else if (event.axis) {
-          event.deltaX = event.axis === 1 ? event.detail : 0;
-          event.deltaY = event.axis === 2 ? event.detail : 0;
-        }
-        // Mobile devices, must calculate the scroll direction.
-        else if (event.type === 'touchmove' && PREV_EVENT) {
-          event.deltaX = event.pageX - PREV_EVENT.pageX;
-          event.deltaY = PREV_EVENT.pageY - event.pageY;
-        }
       }
     };
   })();

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -143,18 +143,6 @@ method is called on the element.
           allowOutsideScroll: {
             type: Boolean,
             value: false
-          },
-
-          /**
-           * Callback for scroll events.
-           * @type {Function}
-           * @private
-           */
-          _boundOnCaptureScroll: {
-            type: Function,
-            value: function() {
-              return this._onCaptureScroll.bind(this);
-            }
           }
         },
 
@@ -181,14 +169,6 @@ method is called on the element.
           return this.focusTarget || this.containedElement;
         },
 
-        ready: function() {
-          // Memoized scrolling position, used to block scrolling outside.
-          this._scrollTop = 0;
-          this._scrollLeft = 0;
-          // Used to perform a non-blocking refit on scroll.
-          this._refitOnScrollRAF = null;
-        },
-
         detached: function() {
           this.cancelAnimation();
           Polymer.IronDropdownScrollManager.removeScrollLock(this);
@@ -205,12 +185,9 @@ method is called on the element.
             this.cancelAnimation();
             this.sizingTarget = this.containedElement || this.sizingTarget;
             this._updateAnimationConfig();
-            this._saveScrollPosition();
-            if (this.opened) {
-              document.addEventListener('scroll', this._boundOnCaptureScroll);
-              !this.allowOutsideScroll && Polymer.IronDropdownScrollManager.pushScrollLock(this);
+            if (this.opened && !this.allowOutsideScroll) {
+              Polymer.IronDropdownScrollManager.pushScrollLock(this);
             } else {
-              document.removeEventListener('scroll', this._boundOnCaptureScroll);
               Polymer.IronDropdownScrollManager.removeScrollLock(this);
             }
             Polymer.IronOverlayBehaviorImpl._openedChanged.apply(this, arguments);
@@ -233,7 +210,6 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderClosed: function() {
-
           if (!this.noAnimations && this.animationConfig.close) {
             this.$.contentWrapper.classList.add('animating');
             this.playAnimation('close');
@@ -254,47 +230,6 @@ method is called on the element.
             this._finishRenderOpened();
           } else {
             this._finishRenderClosed();
-          }
-        },
-
-        _onCaptureScroll: function() {
-          if (!this.allowOutsideScroll) {
-            this._restoreScrollPosition();
-          } else {
-            this._refitOnScrollRAF && window.cancelAnimationFrame(this._refitOnScrollRAF);
-            this._refitOnScrollRAF = window.requestAnimationFrame(this.refit.bind(this));
-          }
-        },
-
-        /**
-         * Memoizes the scroll position of the outside scrolling element.
-         * @private
-         */
-        _saveScrollPosition: function() {
-          if (document.scrollingElement) {
-            this._scrollTop = document.scrollingElement.scrollTop;
-            this._scrollLeft = document.scrollingElement.scrollLeft;
-          } else {
-            // Since we don't know if is the body or html, get max.
-            this._scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
-            this._scrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
-          }
-        },
-
-        /**
-         * Resets the scroll position of the outside scrolling element.
-         * @private
-         */
-        _restoreScrollPosition: function() {
-          if (document.scrollingElement) {
-            document.scrollingElement.scrollTop = this._scrollTop;
-            document.scrollingElement.scrollLeft = this._scrollLeft;
-          } else {
-            // Since we don't know if is the body or html, set both.
-            document.documentElement.scrollTop = this._scrollTop;
-            document.documentElement.scrollLeft = this._scrollLeft;
-            document.body.scrollTop = this._scrollTop;
-            document.body.scrollLeft = this._scrollLeft;
           }
         },
 

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -31,22 +31,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
   <script>
-
-    function fireWheel(node, deltaX, deltaY) {
-      // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
-      event.deltaX = deltaX;
-      event.deltaY = deltaY;
-      node.dispatchEvent(event);
-      return event;
-    }
-
     suite('IronDropdownScrollManager', function() {
       var parent;
       var childOne;
       var childTwo;
-      var grandChildOne;
-      var grandChildTwo;
+      var grandchildOne;
+      var grandchildTwo;
       var ancestor;
 
       setup(function() {
@@ -68,44 +58,57 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childTwo))
+            .to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildTwo))
+            .to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
+            .to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(ancestor))
+            .to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childOne))
+            .to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildOne))
+            .to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
+            .to.be.equal(false);
         });
 
         test('does not check locked elements when there are no locking elements', function() {
-          sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
-          fireWheel(childOne, 0, 10);
+          sinon.spy(Polymer.IronDropdownScrollManager, 'elementIsScrollLocked');
+          childOne.dispatchEvent(new CustomEvent('wheel', {
+            bubbles: true,
+            cancelable: true
+          }));
           expect(Polymer.IronDropdownScrollManager
-              .shouldPreventScrolling.callCount).to.be.eql(1);
+              .elementIsScrollLocked.callCount).to.be.eql(1);
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          fireWheel(childOne, 0, 10);
+          childOne.dispatchEvent(new CustomEvent('wheel', {
+            bubbles: true,
+            cancelable: true
+          }));
           expect(Polymer.IronDropdownScrollManager
-              .shouldPreventScrolling.callCount).to.be.eql(1);
+              .elementIsScrollLocked.callCount).to.be.eql(1);
         });
 
         suite('various scroll events', function() {
@@ -121,13 +124,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ];
 
             events = scrollEvents.map(function(scrollEvent) {
-              var event = new CustomEvent(scrollEvent, {
+              return new CustomEvent(scrollEvent, {
                 bubbles: true,
                 cancelable: true
               });
-              event.deltaX = 0;
-              event.deltaY = 10;
-              return event;
             });
           });
 

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -9,7 +9,6 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
-
 <head>
   <meta charset="UTF-8">
   <title>iron-dropdown basic tests</title>
@@ -55,7 +54,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     height: 3000px;
   }
 </style>
-
 <body>
 
   <test-fixture id="TrivialDropdown">
@@ -135,7 +133,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-
   <script>
     function elementIsVisible(element) {
       var contentRect = element.getBoundingClientRect();
@@ -149,24 +146,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function runAfterOpen(overlay, callback) {
       overlay.addEventListener('iron-overlay-opened', callback);
       overlay.open();
-    }
-
-    function fireWheel(node, deltaX, deltaY) {
-      // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {
-        cancelable: true,
-        bubbles: true
-      });
-      event.deltaX = deltaX;
-      event.deltaY = deltaY;
-      node.dispatchEvent(event);
-      return event;
-    }
-
-    function dispatchScroll(target, scrollLeft, scrollTop) {
-      target.scrollLeft = scrollLeft;
-      target.scrollTop = scrollTop;
-      target.dispatchEvent(new CustomEvent('scroll', { bubbles:true } ));
     }
 
     suite('<iron-dropdown>', function() {
@@ -184,14 +163,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('shows dropdown content when opened', function(done) {
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             expect(elementIsVisible(content)).to.be.equal(true);
             done();
           });
         });
 
         test('hides dropdown content when outside is clicked', function(done) {
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             expect(elementIsVisible(content)).to.be.equal(true);
             dropdown.addEventListener('iron-overlay-closed', function() {
               expect(elementIsVisible(content)).to.be.equal(false);
@@ -207,7 +186,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             content = Polymer.dom(dropdown).querySelector('.dropdown-content');
           });
           test('focuses the content when opened', function(done) {
-            runAfterOpen(dropdown, function() {
+            runAfterOpen(dropdown, function () {
               expect(document.activeElement).to.be.equal(content);
               done();
             });
@@ -217,7 +196,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var focusableChild = Polymer.dom(content).querySelector('div[tabindex]');
             dropdown.focusTarget = focusableChild;
 
-            runAfterOpen(dropdown, function() {
+            runAfterOpen(dropdown, function () {
               expect(document.activeElement).to.not.be.equal(content);
               expect(document.activeElement).to.be.equal(focusableChild);
               done();
@@ -228,32 +207,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('locking scroll', function() {
 
-        var bigDiv, scrollTarget;
-        suiteSetup(function() {
-          bigDiv = document.createElement('div');
-          bigDiv.classList.add('big');
-          document.body.appendChild(bigDiv);
-          // Need to discover if html or body is scrollable.
-          // Here we are sure the page is scrollable.
-          document.documentElement.scrollTop = 1;
-          if (document.documentElement.scrollTop === 1) {
-            document.documentElement.scrollTop = 0;
-            scrollTarget = document.documentElement;
-          } else {
-            scrollTarget = document.body;
-          }
-        });
-
-        suiteTeardown(function() {
-          document.body.removeChild(bigDiv);
-        });
-
         setup(function() {
           dropdown = fixture('TrivialDropdown');
-        });
-
-        teardown(function() {
-          dispatchScroll(scrollTarget, 0, 0);
         });
 
         test('should lock, only once', function(done) {
@@ -261,9 +216,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
-            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
+            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
+              .to.be.equal(true);
 
-            if (openCount === 0) {
+            if(openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
               // that should not add the element to the `_lockingElements` stack twice
               dropdown.close();
@@ -274,26 +230,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             openCount++;
           });
         });
-
-        test('should lock scroll', function(done) {
-          runAfterOpen(dropdown, function() {
-            dispatchScroll(scrollTarget, 10, 10);
-            assert.equal(scrollTarget.scrollTop, 0, 'scrollTop ok');
-            assert.equal(scrollTarget.scrollLeft, 0, 'scrollLeft ok');
-            done();
-          });
-        });
-
-        test('can be disabled with `allowOutsideScroll`', function(done) {
-          dropdown.allowOutsideScroll = true;
-          runAfterOpen(dropdown, function() {
-            dispatchScroll(scrollTarget, 10, 10);
-            assert.equal(scrollTarget.scrollTop, 10, 'scrollTop ok');
-            assert.equal(scrollTarget.scrollLeft, 10, 'scrollLeft ok');
-            done();
-          });
-        });
-
       });
 
       suite('non locking scroll', function() {
@@ -304,7 +240,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
           runAfterOpen(dropdown, function() {
-            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
+            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
+              .to.be.equal(false);
             done();
           });
         });
@@ -318,15 +255,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function() {
           parent = fixture('AlignedDropdown');
           dropdown = parent.querySelector('iron-dropdown');
-          parentRect = parent.getBoundingClientRect();
         });
 
         test('can be re-aligned to the right and the top', function(done) {
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
+            parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
-            assert.equal(dropdownRect.bottom, window.innerHeight, 'bottom ok');
+            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
             assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });
@@ -334,7 +271,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be re-aligned to the bottom', function(done) {
           dropdown.verticalAlign = 'bottom';
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
+            parentRect = parent.getBoundingClientRect();
             dropdownRect = dropdown.getBoundingClientRect();
             assert.equal(dropdownRect.top, 0, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
@@ -347,11 +285,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('handles parent\'s stacking context', function(done) {
           // This will create a new stacking context.
           parent.style.transform = 'translateZ(0)';
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
+            parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
-            assert.equal(dropdownRect.bottom, window.innerHeight, 'bottom ok');
+            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
             assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });
@@ -367,7 +306,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the bottom right', function(done) {
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
@@ -383,7 +322,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the top left', function(done) {
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
@@ -408,7 +347,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the top left', function(done) {
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
@@ -424,7 +363,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the bottom right', function(done) {
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
@@ -446,7 +385,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=left', function(done) {
           var parent = fixture('RTLDropdownLeft');
           dropdown = parent.querySelector('iron-dropdown');
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             // In RTL, if `horizontalAlign` is "left", that's the same as
             // being right-aligned in LTR. So the dropdown should be in the top
             // right corner.
@@ -460,7 +399,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=right', function(done) {
           var parent = fixture('RTLDropdownRight');
           dropdown = parent.querySelector('iron-dropdown');
-          runAfterOpen(dropdown, function() {
+          runAfterOpen(dropdown, function () {
             // In RTL, if `horizontalAlign` is "right", that's the same as
             // being left-aligned in LTR. So the dropdown should be in the top
             // left corner.
@@ -474,5 +413,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </body>
-
 </html>

--- a/test/x-scrollable-element.html
+++ b/test/x-scrollable-element.html
@@ -12,37 +12,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="x-scrollable-element">
   <template>
-    <style>
-      :host {
-        display: block;
-        height: 100px;
-        border: 1px solid red;
-        overflow: auto;
-      }
-      #ChildOne, #ChildTwo {
-        height: 200px;
-        border: 1px solid blue;
-        overflow: auto;
-      }
-      #GrandchildOne, #GrandchildTwo {
-        height: 300px;
-        border: 1px solid green;
-        overflow: auto;
-      }
-      .scrollContent {
-        height: 400px;
-        background-color: yellow;
-      }
-    </style>
     <div id="ChildOne">
-      <div id="GrandchildOne">
-        <div class="scrollContent"></div>
-      </div>
+      <div id="GrandchildOne"></div>
     </div>
     <div id="ChildTwo">
-      <div id="GrandchildTwo">
-        <div class="scrollContent"></div>
-      </div>
+      <div id="GrandchildTwo"></div>
     </div>
   </template>
   <script>


### PR DESCRIPTION
Reverts PolymerElements/iron-dropdown#64 as it removed a public method, which is a breaking change that needs to be first investigated.