### PR TITLE
keep overflow, prevent events that cause scrolling

### DIFF
--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -14,12 +14,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   (function() {
     'use strict';
+    // Used to calculate the scroll direction.
+    var lastTouch = null;
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
      * of authority and control over which elements in a document are currently
      * allowed to scroll.
      */
+
 
     Polymer.IronDropdownScrollManager = {
 
@@ -33,39 +36,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
       /**
-       * Returns true if the provided element is "scroll locked," which is to
-       * say that it cannot be scrolled via pointer or keyboard interactions.
+       * Returns true if the element causing the scroll is "scroll locked," which is to
+       * say that it cannot be scrolled via pointer or keyboard interactions, or
+       * if already at its scroll boundaries.
        *
-       * @param {HTMLElement} element An HTML element instance which may or may
-       * not be scroll locked.
+       * @param {Event} event The scroll event
        */
-      elementIsScrollLocked: function(element) {
-        var currentLockingElement = this.currentLockingElement;
+      shouldPreventScrolling: function(event) {
+        // Avoid expensive checks if the event is not one of the observed keys.
+        if (event.type === 'keydown' && !this._isScrollingKeypress(event)) {
+          return false;
+        }
 
+        var currentLockingElement = this.currentLockingElement;
         if (currentLockingElement === undefined)
           return false;
 
-        var scrollLocked;
-
-        if (this._hasCachedLockedElement(element)) {
-          return true;
+        var nodes = Polymer.dom(event).path;
+        var lockingIndex = nodes.indexOf(currentLockingElement);
+        var isScrollingRight = event.wheelDeltaX > 0;
+        var isScrollingUp = event.wheelDeltaY > 0;
+        if (event.type === 'touchmove' && lastTouch) {
+          isScrollingUp = event.pageY > lastTouch.pageY;
+          isScrollingRight = lastTouch.pageX > event.pageX;
         }
-
-        if (this._hasCachedUnlockedElement(element)) {
-          return false;
+        // Search for one scrollable that can still scroll, stop at the locked element.
+        for (var i = 0; i < lockingIndex; i++) {
+          var node = nodes[i];
+          // Skip nodes that are not scrollable.
+          if (node.scrollHeight <= node.clientHeight && node.scrollWidth <= node.clientWidth) {
+            continue;
+          }
+          var canScrollVertically = isScrollingUp ? node.scrollTop > 0 :
+              node.scrollTop + node.clientHeight < node.scrollHeight;
+          var canScrollHorizontally = isScrollingRight ? node.scrollLeft > 0 :
+              node.scrollLeft + node.clientWidth < node.scrollWidth;
+          // If it can scroll, don't prevent.
+          if (canScrollVertically || canScrollHorizontally) {
+            return false;
+          }
         }
-
-        scrollLocked = !!currentLockingElement &&
-          currentLockingElement !== element &&
-          !this._composedTreeContains(currentLockingElement, element);
-
-        if (scrollLocked) {
-          this._lockedElementCache.push(element);
-        } else {
-          this._unlockedElementCache.push(element);
-        }
-
-        return scrollLocked;
+        // Don't prevent if event's target is currentLockingElement.
+        return (lockingIndex !== 0);
       },
 
       /**
@@ -89,9 +101,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         this._lockingElements.push(element);
-
-        this._lockedElementCache = [];
-        this._unlockedElementCache = [];
       },
 
       /**
@@ -112,19 +121,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         this._lockingElements.splice(index, 1);
 
-        this._lockedElementCache = [];
-        this._unlockedElementCache = [];
-
         if (this._lockingElements.length === 0) {
           this._unlockScrollInteractions();
         }
       },
 
       _lockingElements: [],
-
-      _lockedElementCache: null,
-
-      _unlockedElementCache: null,
 
       _originalBodyStyles: {},
 
@@ -133,78 +135,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           event, 'pageup pagedown home end up left down right');
       },
 
-      _hasCachedLockedElement: function(element) {
-        return this._lockedElementCache.indexOf(element) > -1;
-      },
-
-      _hasCachedUnlockedElement: function(element) {
-        return this._unlockedElementCache.indexOf(element) > -1;
-      },
-
-      _composedTreeContains: function(element, child) {
-        // NOTE(cdata): This method iterates over content elements and their
-        // corresponding distributed nodes to implement a contains-like method
-        // that pierces through the composed tree of the ShadowDOM. Results of
-        // this operation are cached (elsewhere) on a per-scroll-lock basis, to
-        // guard against potentially expensive lookups happening repeatedly as
-        // a user scrolls / touchmoves.
-        var contentElements;
-        var distributedNodes;
-        var contentIndex;
-        var nodeIndex;
-
-        if (element.contains(child)) {
-          return true;
-        }
-
-        contentElements = Polymer.dom(element).querySelectorAll('content');
-
-        for (contentIndex = 0; contentIndex < contentElements.length; ++contentIndex) {
-
-          distributedNodes = Polymer.dom(contentElements[contentIndex]).getDistributedNodes();
-
-          for (nodeIndex = 0; nodeIndex < distributedNodes.length; ++nodeIndex) {
-
-            if (this._composedTreeContains(distributedNodes[nodeIndex], child)) {
-              return true;
-            }
-          }
-        }
-
-        return false;
-      },
-
       _scrollInteractionHandler: function(event) {
-        var scrolledElement =
-            /** @type {HTMLElement} */(Polymer.dom(event).rootTarget);
-        if (Polymer
-              .IronDropdownScrollManager
-              .elementIsScrollLocked(scrolledElement)) {
-          if (event.type === 'keydown' &&
-              !Polymer.IronDropdownScrollManager._isScrollingKeypress(event)) {
-            return;
-          }
-
+        if (Polymer.IronDropdownScrollManager.shouldPreventScrolling(event)) {
           event.preventDefault();
         }
+        lastTouch = event;
       },
 
       _lockScrollInteractions: function() {
-        // Memoize body inline styles:
-        this._originalBodyStyles.overflow = document.body.style.overflow;
-        this._originalBodyStyles.overflowX = document.body.style.overflowX;
-        this._originalBodyStyles.overflowY = document.body.style.overflowY;
-
-        // Disable overflow scrolling on body:
-        // TODO(cdata): It is technically not sufficient to hide overflow on
-        // body alone. A better solution might be to traverse all ancestors of
-        // the current scroll locking element and hide overflow on them. This
-        // becomes expensive, though, as it would have to be redone every time
-        // a new scroll locking element is added.
-        document.body.style.overflow = 'hidden';
-        document.body.style.overflowX = 'hidden';
-        document.body.style.overflowY = 'hidden';
-
         // Modern `wheel` event for mouse wheel scrolling:
         document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
@@ -218,10 +156,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _unlockScrollInteractions: function() {
-        document.body.style.overflow = this._originalBodyStyles.overflow;
-        document.body.style.overflowX = this._originalBodyStyles.overflowX;
-        document.body.style.overflowY = this._originalBodyStyles.overflowY;
-
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
@@ -230,4 +164,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     };
   })();
+
 </script>

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -43,8 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       shouldPreventScrolling: function(event) {
         // Avoid expensive checks if the event is not one of the observed keys.
-        if (event.type === 'keydown' && !this._isScrollingKeypress(event)) {
-          return false;
+        if (event.type === 'keydown') {
+          // Prevent event if it is one of the scrolling keys.
+          return this._isScrollingKeypress(event);
         }
 
         var lockingElement = this.currentLockingElement;
@@ -130,8 +131,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _lockingElements: [],
-
-      _originalBodyStyles: {},
 
       _isScrollingKeypress: function(event) {
         return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -219,25 +219,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return false;
         }
 
-        // Makes sure deltaX/Y are set.
-        this._normalizeWheelDelta(event);
+        // Get deltaX/Y info.
+        var info = this._getScrollDeltaInfo(event);
 
         // Prevent if there is no child inside locking element that can scroll.
         var shouldPrevent = true;
         // Check either vertical or horizontal, according to where
         // there was more scroll. Prefer vertical over horizontal.
-        var isScrollVertical = Math.abs(event.deltaY) >= Math.abs(event.deltaX);
+        var verticalScroll = Math.abs(info.deltaY) >= Math.abs(info.deltaX);
         // Loop from root target to locking element (included).
         for (var i = 0; i <= lockingIndex; i++) {
           var node = EVENT_PATH[i];
           var canScroll = false;
-          if (isScrollVertical) {
+          if (verticalScroll) {
             // delta < 0 = scroll up, else scroll down.
-            canScroll = event.deltaY < 0 ? node.scrollTop > 0 :
+            canScroll = info.deltaY < 0 ? node.scrollTop > 0 :
               node.scrollTop < node.scrollHeight - node.clientHeight;
           } else {
             // delta < 0 = scroll left, else scroll right.
-            canScroll = event.deltaX < 0 ? node.scrollLeft > 0 :
+            canScroll = info.deltaX < 0 ? node.scrollLeft > 0 :
               node.scrollLeft < node.scrollWidth - node.clientWidth;
           }
           // If it can scroll, don't prevent.
@@ -250,33 +250,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Normalizes `deltaX` and `deltaY` of the event.
+       * Returns `deltaX` and `deltaY` of the event normalized cross-browsers.
        * Positive value: scroll down/right
        * Negative value: scroll up/left.
        * @param {!Event} event The scroll event
+       * @return {{
+       *  deltaX: number,
+       *  deltaY: number}} info
        * @private
        */
-      _normalizeWheelDelta: function(event) {
-        // Already set, return.
+      _getScrollDeltaInfo: function(event) {
+        var info = {
+          deltaX: event.deltaX,
+          deltaY: event.deltaY
+        };
+        // Already available.
         if (event.deltaX || event.deltaY) {
-          return;
+          // do nothing, values are already good.
         }
         // Safari has scroll info in `wheelDeltaX/Y`.
-        if (event.wheelDeltaX || event.wheelDeltaY) {
-          event.deltaX = -event.wheelDeltaX;
-          event.deltaY = -event.wheelDeltaY;
+        else if (event.wheelDeltaX || event.wheelDeltaY) {
+          info.deltaX = -event.wheelDeltaX;
+          info.deltaY = -event.wheelDeltaY;
         }
         // Firefox has scroll info in `detail` and `axis`.
         else if (event.axis) {
-          event.deltaX = event.axis === 1 ? event.detail : 0;
-          event.deltaY = event.axis === 2 ? event.detail : 0;
+          info.deltaX = event.axis === 1 ? event.detail : 0;
+          info.deltaY = event.axis === 2 ? event.detail : 0;
         }
         // On mobile devices, calculate scroll direction.
         else {
           var touch = this._getTouchFromEvent(event);
-          event.deltaX = touch.pageX - PREVIOUS_TOUCH.pageX;
-          event.deltaY = PREVIOUS_TOUCH.pageY - touch.pageY;
+          info.deltaX = touch.pageX - PREVIOUS_TOUCH.pageX;
+          info.deltaY = PREVIOUS_TOUCH.pageY - touch.pageY;
         }
+        return info;
       }
     };
   })();

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -33,15 +33,163 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       get currentLockingElement() {
         return this._lockingElements[this._lockingElements.length - 1];
       },
-      
+
       /**
-       * Returns true if the element causing the scroll is "scroll locked",
-       * meaning it cannot be scrolled via pointer or keyboard interactions, or
-       * if already at its scroll boundaries.
+       * Returns true if the provided element is "scroll locked", which is to
+       * say that it cannot be scrolled via pointer or keyboard interactions.
        *
-       * @param {Event} event The scroll event
+       * @param {HTMLElement} element An HTML element instance which may or may
+       * not be scroll locked.
        */
-      shouldPreventScrolling: function(event) {
+      elementIsScrollLocked: function(element) {
+        var currentLockingElement = this.currentLockingElement;
+
+        if (currentLockingElement === undefined)
+          return false;
+
+        var scrollLocked;
+
+        if (this._hasCachedLockedElement(element)) {
+          return true;
+        }
+
+        if (this._hasCachedUnlockedElement(element)) {
+          return false;
+        }
+
+        scrollLocked = !!currentLockingElement &&
+          currentLockingElement !== element &&
+          !Polymer.dom(currentLockingElement).deepContains(element);
+
+        if (scrollLocked) {
+          this._lockedElementCache.push(element);
+        } else {
+          this._unlockedElementCache.push(element);
+        }
+
+        return scrollLocked;
+      },
+
+      /**
+       * Push an element onto the current scroll lock stack. The most recently
+       * pushed element and its children will be considered scrollable. All
+       * other elements will not be scrollable.
+       *
+       * Scroll locking is implemented as a stack so that cases such as
+       * dropdowns within dropdowns are handled well.
+       *
+       * @param {HTMLElement} element The element that should lock scroll.
+       */
+      pushScrollLock: function(element) {
+        // Prevent pushing the same element twice
+        if (this._lockingElements.indexOf(element) >= 0) {
+          return;
+        }
+
+        if (this._lockingElements.length === 0) {
+          this._lockScrollInteractions();
+        }
+
+        this._lockingElements.push(element);
+
+        this._lockedElementCache = [];
+        this._unlockedElementCache = [];
+      },
+
+      /**
+       * Remove an element from the scroll lock stack. The element being
+       * removed does not need to be the most recently pushed element. However,
+       * the scroll lock constraints only change when the most recently pushed
+       * element is removed.
+       *
+       * @param {HTMLElement} element The element to remove from the scroll
+       * lock stack.
+       */
+      removeScrollLock: function(element) {
+        var index = this._lockingElements.indexOf(element);
+
+        if (index === -1) {
+          return;
+        }
+
+        this._lockingElements.splice(index, 1);
+
+        this._lockedElementCache = [];
+        this._unlockedElementCache = [];
+
+        if (this._lockingElements.length === 0) {
+          this._unlockScrollInteractions();
+        }
+
+      },
+
+      _lockingElements: [],
+
+      _lockedElementCache: null,
+
+      _unlockedElementCache: null,
+
+      _isScrollingKeypress: function(event) {
+        return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(
+          event, 'pageup pagedown home end up left down right');
+      },
+
+      _hasCachedLockedElement: function(element) {
+        return this._lockedElementCache.indexOf(element) > -1;
+      },
+
+      _hasCachedUnlockedElement: function(element) {
+        return this._unlockedElementCache.indexOf(element) > -1;
+      },
+
+      _scrollInteractionHandler: function(event) {
+        if (event.type === 'touchstart') {
+          // Memoize it, since on mobile the scroll gesture might happen outside
+          // the element initially touched.
+          EVENT_PATH = Polymer.dom(event).path;
+        }
+        if (this._shouldPreventScrolling(event)) {
+          event.preventDefault();
+        }
+        PREV_EVENT = event;
+      },
+
+      _lockScrollInteractions: function() {
+        this._boundScrollHandler = this._boundScrollHandler ||
+          this._scrollInteractionHandler.bind(this);
+        // Modern `wheel` event for mouse wheel scrolling:
+        document.addEventListener('wheel', this._boundScrollHandler, true);
+        // Older, non-standard `mousewheel` event for some FF:
+        document.addEventListener('mousewheel', this._boundScrollHandler, true);
+        // IE:
+        document.addEventListener('DOMMouseScroll', this._boundScrollHandler, true);
+        // Save the EVENT_PATH on touchstart, to be used on touchmove.
+        document.addEventListener('touchstart', this._boundScrollHandler, true);
+        // Mobile devices can scroll on touch move:
+        document.addEventListener('touchmove', this._boundScrollHandler, true);
+        // Capture keydown to prevent scrolling keys (pageup, pagedown etc.)
+        document.addEventListener('keydown', this._boundScrollHandler, true);
+      },
+
+      _unlockScrollInteractions: function() {
+        document.removeEventListener('wheel', this._boundScrollHandler, true);
+        document.removeEventListener('mousewheel', this._boundScrollHandler, true);
+        document.removeEventListener('DOMMouseScroll', this._boundScrollHandler, true);
+        document.removeEventListener('touchstart', this._boundScrollHandler, true);
+        document.removeEventListener('touchmove', this._boundScrollHandler, true);
+        document.removeEventListener('keydown', this._boundScrollHandler, true);
+      },
+
+      /**
+       * Returns true if the event causes scroll outside the current locking
+       * element, e.g. pointer or keyboard interactions, or scroll "leaking"
+       * outside the locking element when it is already at its scroll boundaries.
+       *
+       * @param {!Event} event The scroll event
+       * @return {boolean}
+       * @private
+       */
+      _shouldPreventScrolling: function(event) {
         var lockingElement = this.currentLockingElement;
         if (!lockingElement) {
           return false;
@@ -87,98 +235,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         // Don't prevent if event's target is the current locking element.
         return lockingIndex !== 0;
-      },
-
-      /**
-       * Push an element onto the current scroll lock stack. The most recently
-       * pushed element and its children will be considered scrollable. All
-       * other elements will not be scrollable.
-       *
-       * Scroll locking is implemented as a stack so that cases such as
-       * dropdowns within dropdowns are handled well.
-       *
-       * @param {HTMLElement} element The element that should lock scroll.
-       */
-      pushScrollLock: function(element) {
-        // Prevent pushing the same element twice
-        if (this._lockingElements.indexOf(element) >= 0) {
-          return;
-        }
-
-        if (this._lockingElements.length === 0) {
-          this._lockScrollInteractions();
-        }
-
-        this._lockingElements.push(element);
-      },
-
-      /**
-       * Remove an element from the scroll lock stack. The element being
-       * removed does not need to be the most recently pushed element. However,
-       * the scroll lock constraints only change when the most recently pushed
-       * element is removed.
-       *
-       * @param {HTMLElement} element The element to remove from the scroll
-       * lock stack.
-       */
-      removeScrollLock: function(element) {
-        var index = this._lockingElements.indexOf(element);
-
-        if (index === -1) {
-          return;
-        }
-
-        this._lockingElements.splice(index, 1);
-
-        if (this._lockingElements.length === 0) {
-          this._unlockScrollInteractions();
-        }
-      },
-
-      _lockingElements: [],
-
-      _touchstartHandler: function(event) {
-        // Memoize it, since on mobile the scroll gesture might happen outside
-        // the element initially touched.
-        EVENT_PATH = Polymer.dom(event).path;
-        // Will prevent if touch happened outside the locked element.
-        Polymer.IronDropdownScrollManager._scrollInteractionHandler(event);
-      },
-
-      _isScrollingKeypress: function(event) {
-        return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(
-          event, 'pageup pagedown home end up left down right');
-      },
-
-      _scrollInteractionHandler: function(event) {
-        if (Polymer.IronDropdownScrollManager.shouldPreventScrolling(event)) {
-          event.preventDefault();
-        }
-        PREV_EVENT = event;
-      },
-
-      _lockScrollInteractions: function() {
-        // Modern `wheel` event for mouse wheel scrolling:
-        document.addEventListener('wheel', this._scrollInteractionHandler, true);
-        // Older, non-standard `mousewheel` event for some FF:
-        document.addEventListener('mousewheel', this._scrollInteractionHandler, true);
-        // IE:
-        document.addEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
-        // Save the EVENT_PATH on touchstart, to be used on touchmove.
-        document.addEventListener('touchstart', this._touchstartHandler, true);
-        // Mobile devices can scroll on touch move:
-        document.addEventListener('touchmove', this._scrollInteractionHandler, true);
-        // Capture keydown to prevent scrolling keys (pageup, pagedown etc.)
-        document.addEventListener('keydown', this._scrollInteractionHandler, true);
-      },
-
-      _unlockScrollInteractions: function() {
-        document.removeEventListener('wheel', this._scrollInteractionHandler, true);
-        document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
-        document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
-        document.removeEventListener('touchstart', this._touchstartHandler, true);
-        document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
-        document.removeEventListener('keydown', this._scrollInteractionHandler, true);
       },
 
       /**

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -49,35 +49,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         var currentLockingElement = this.currentLockingElement;
-        if (currentLockingElement === undefined)
+        if (currentLockingElement === undefined) {
           return false;
+        }
+
+        var xDelta = event.wheelDeltaX;
+        var yDelta = event.wheelDeltaY;
+        if (event.type === 'touchmove' && lastTouch) {
+          xDelta = lastTouch.pageX - event.pageX;
+          yDelta = event.pageY - lastTouch.pageY;
+        }
 
         var nodes = Polymer.dom(event).path;
         var lockingIndex = nodes.indexOf(currentLockingElement);
-        var isScrollingRight = event.wheelDeltaX > 0;
-        var isScrollingUp = event.wheelDeltaY > 0;
-        if (event.type === 'touchmove' && lastTouch) {
-          isScrollingUp = event.pageY > lastTouch.pageY;
-          isScrollingRight = lastTouch.pageX > event.pageX;
-        }
         // Search for one scrollable that can still scroll, stop at the locked element.
         for (var i = 0; i < lockingIndex; i++) {
           var node = nodes[i];
-          // Skip nodes that are not scrollable.
-          if (node.scrollHeight <= node.clientHeight && node.scrollWidth <= node.clientWidth) {
-            continue;
+
+          // Check either vertical or horizontal, according to where
+          // there was more scroll.
+          var scrollDelta, scrollableSize, scrollPos;
+          if (Math.abs(yDelta) >= Math.abs(xDelta)) {
+            scrollDelta = yDelta;
+            scrollableSize = node.scrollHeight - node.clientHeight;
+            scrollPos = node.scrollTop;
+          } else {
+            scrollDelta = xDelta;
+            scrollableSize = node.scrollWidth - node.clientWidth;
+            scrollPos = node.scrollLeft;
           }
-          var canScrollVertically = isScrollingUp ? node.scrollTop > 0 :
-              node.scrollTop + node.clientHeight < node.scrollHeight;
-          var canScrollHorizontally = isScrollingRight ? node.scrollLeft > 0 :
-              node.scrollLeft + node.clientWidth < node.scrollWidth;
           // If it can scroll, don't prevent.
-          if (canScrollVertically || canScrollHorizontally) {
+          if (scrollDelta !== 0 && scrollableSize > 0 &&
+              (scrollDelta > 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
             return false;
           }
         }
         // Don't prevent if event's target is currentLockingElement.
-        return (lockingIndex !== 0);
+        return lockingIndex !== 0;
       },
 
       /**

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -15,7 +15,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
     // Used to calculate the scroll direction.
-    var PREV_EVENT = null;
+    var PREVIOUS_TOUCH = {
+      pageX: 0,
+      pageY: 0
+    };
     // Memoized event path for better perf. For touch events, it gets saved on
     // touchstart and consumed during touchmove.
     var EVENT_PATH = [];
@@ -148,7 +151,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this._shouldPreventScrolling(event)) {
           event.preventDefault();
         }
-        PREV_EVENT = event;
+        var touch = this._getTouchFromEvent(event);
+        PREVIOUS_TOUCH.pageX = touch.pageX;
+        PREVIOUS_TOUCH.pageY = touch.pageY;
       },
 
       _lockScrollInteractions: function() {
@@ -175,6 +180,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.removeEventListener('touchstart', this._boundScrollHandler, true);
         document.removeEventListener('touchmove', this._boundScrollHandler, true);
         document.removeEventListener('keydown', this._boundScrollHandler, true);
+      },
+
+      _getTouchFromEvent: function(event) {
+        return event.targetTouches ? event.targetTouches[0] : event;
       },
 
       /**
@@ -262,12 +271,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           event.deltaX = event.axis === 1 ? event.detail : 0;
           event.deltaY = event.axis === 2 ? event.detail : 0;
         }
-        // On mobile devices, calculate scroll direction using targetTouches.
-        else if (event.targetTouches && PREV_EVENT) {
-          var currentTouch = event.targetTouches[0];
-          var previousTouch = PREV_EVENT.targetTouches[0];
-          event.deltaX = currentTouch.pageX - previousTouch.pageX;
-          event.deltaY = previousTouch.pageY - currentTouch.pageY;
+        // On mobile devices, calculate scroll direction.
+        else {
+          var touch = this._getTouchFromEvent(event);
+          event.deltaX = touch.pageX - PREVIOUS_TOUCH.pageX;
+          event.deltaY = PREVIOUS_TOUCH.pageY - touch.pageY;
         }
       }
     };

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -33,8 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       get currentLockingElement() {
         return this._lockingElements[this._lockingElements.length - 1];
       },
-
-
+      
       /**
        * Returns true if the element causing the scroll is "scroll locked",
        * meaning it cannot be scrolled via pointer or keyboard interactions, or
@@ -43,42 +42,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {Event} event The scroll event
        */
       shouldPreventScrolling: function(event) {
+        var lockingElement = this.currentLockingElement;
+        if (!lockingElement) {
+          return false;
+        }
         // Avoid expensive checks if the event is not one of the observed keys.
         if (event.type === 'keydown') {
           // Prevent event if it is one of the scrolling keys.
           return this._isScrollingKeypress(event);
         }
 
-        var lockingElement = this.currentLockingElement;
-        if (!lockingElement) {
-          return false;
-        }
-
         // Makes sure deltaX/Y are set.
         this._normalizeWheelDelta(event);
-        // No scrolling.
-        if (!event.deltaX && !event.deltaY) {
-          return false;
-        }
+
         // Check either vertical or horizontal, according to where
         // there was more scroll.
-        var scrollDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ?
-          event.deltaY : event.deltaX;
+        var isScrollVertical = Math.abs(event.deltaY) >= Math.abs(event.deltaX);
+        // delta < 0 = scroll up, delta > 0 = scroll down.
+        var isScrollUp = isScrollVertical ? event.deltaY < 0 : event.deltaX < 0;
 
-        // Check if EVENT_PATH needs to be updated. For touch events rely on the
-        // `EVENT_PATH` saved on touchstart.
-        if (event.type !== 'touchmove') {
+        // EVENT_PATH is memoized for better perf and updated if needed.
+        // For touch events rely on the EVENT_PATH saved on touchstart.
+        if (event.type !== 'touchmove' &&
+          EVENT_PATH[0] !== Polymer.dom(event).rootTarget) {
           EVENT_PATH = Polymer.dom(event).path;
         }
+        // Search for one scrollable that can still scroll up to locked element.
         var lockingIndex = EVENT_PATH.indexOf(lockingElement);
-        // Search for one scrollable that can still scroll, stop at the locked element.
-        for (var i = 0; i < lockingIndex; i++) {
-          var node = EVENT_PATH[i];
-          var scrollableSize = scrollDelta === event.deltaY ?
-            node.scrollHeight - node.clientHeight : node.scrollWidth - node.clientWidth;
-          var scrollPos = scrollDelta === event.deltaY ? node.scrollTop : node.scrollLeft;
+        var i, node, canScroll;
+        for (i = 0; i < lockingIndex; i++) {
+          node = EVENT_PATH[i];
+          canScroll = false;
+          if (isScrollVertical) {
+            canScroll = isScrollUp ? node.scrollTop > 0 :
+              node.scrollTop < node.scrollHeight - node.clientHeight;
+          } else {
+            canScroll = isScrollUp ? node.scrollLeft > 0 :
+              node.scrollLeft < node.scrollWidth - node.clientWidth;
+          }
           // If it can scroll, don't prevent.
-          if (scrollableSize > 0 && (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
+          if (canScroll) {
             return false;
           }
         }
@@ -138,6 +141,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Memoize it, since on mobile the scroll gesture might happen outside
         // the element initially touched.
         EVENT_PATH = Polymer.dom(event).path;
+        // Will prevent if touch happened outside the locked element.
+        Polymer.IronDropdownScrollManager._scrollInteractionHandler(event);
       },
 
       _isScrollingKeypress: function(event) {
@@ -199,8 +204,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         // Mobile devices, must calculate the scroll direction.
         else if (event.type === 'touchmove' && PREV_EVENT) {
-          event.deltaX = event.pageX - PREV_EVENT.pageX;
-          event.deltaY = PREV_EVENT.pageY - event.pageY;
+          var currentTouch = event.targetTouches[0];
+          var previousTouch = PREV_EVENT.targetTouches[0];
+          event.deltaX = currentTouch.pageX - previousTouch.pageX;
+          event.deltaY = previousTouch.pageY - currentTouch.pageY;
         }
       }
     };

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -201,26 +201,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         var lockingIndex = EVENT_PATH.indexOf(this.currentLockingElement);
-        // Prevent event dispatched by an element outside the locking element,
-        // don't prevent event dispatched by the locking element.
-        if (lockingIndex <= 0) {
-          return lockingIndex < 0;
+        // Prevent event dispatched by an element outside the locking element.
+        if (lockingIndex < 0) {
+          return true;
+        }
+        // Don't prevent touchstart events inside the locking element.
+        if (event.type === 'touchstart') {
+          return false;
         }
 
         // Makes sure deltaX/Y are set.
         this._normalizeWheelDelta(event);
-        // If no scroll (e.g. on touchstart), don't prevent.
-        if (!event.deltaX && !event.deltaY) {
-          return false;
-        }
 
         // Prevent if there is no child inside locking element that can scroll.
         var shouldPrevent = true;
         // Check either vertical or horizontal, according to where
         // there was more scroll. Prefer vertical over horizontal.
         var isScrollVertical = Math.abs(event.deltaY) >= Math.abs(event.deltaX);
-        // Loop from root target to locking element (excluded).
-        for (var i = 0; i < lockingIndex; i++) {
+        // Loop from root target to locking element (included).
+        for (var i = 0; i <= lockingIndex; i++) {
           var node = EVENT_PATH[i];
           var canScroll = false;
           if (isScrollVertical) {
@@ -263,8 +262,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           event.deltaX = event.axis === 1 ? event.detail : 0;
           event.deltaY = event.axis === 2 ? event.detail : 0;
         }
-        // Mobile devices, must calculate the scroll direction.
-        else if (event.type === 'touchmove' && PREV_EVENT) {
+        // On mobile devices, calculate scroll direction using targetTouches.
+        else if (event.targetTouches && PREV_EVENT) {
           var currentTouch = event.targetTouches[0];
           var previousTouch = PREV_EVENT.targetTouches[0];
           event.deltaX = currentTouch.pageX - previousTouch.pageX;

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -196,6 +196,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @private
        */
       _shouldPreventScrolling: function(event) {
+        // Avoid canceling an event with cancelable=false, e.g. scrolling is in
+        // progress and cannot be interrupted.
+        if (!event.cancelable) {
+          return false;
+        }
         // Avoid expensive checks if the event is not one of the observed keys.
         if (event.type === 'keydown') {
           // Prevent event if it is one of the scrolling keys.

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -23,7 +23,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * allowed to scroll.
      */
 
-
     Polymer.IronDropdownScrollManager = {
 
       /**
@@ -151,6 +150,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _lockScrollInteractions: function() {
+        // Memoize body scroll position
+        this._saveScrollPosition();
+        document.addEventListener('scroll', this._restoreScrollPosition, true);
+
         // Modern `wheel` event for mouse wheel scrolling:
         document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
@@ -164,11 +167,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _unlockScrollInteractions: function() {
+        document.removeEventListener('scroll', this._restoreScrollPosition, true);
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
+      },
+
+      /**
+       * Memoizes the scroll position of the outside scrolling element.
+       * @private
+       */
+      _saveScrollPosition: function() {
+        if (document.scrollingElement) {
+          this._scrollTop = document.scrollingElement.scrollTop;
+          this._scrollLeft = document.scrollingElement.scrollLeft;
+        } else {
+          // Since we don't know if is the body or html, get max.
+          this._scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+          this._scrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
+        }
+      },
+
+      /**
+       * Resets the scroll position of the outside scrolling element.
+       * @private
+       */
+      _restoreScrollPosition: function() {
+        if (document.scrollingElement) {
+          document.scrollingElement.scrollTop = this._scrollTop;
+          document.scrollingElement.scrollLeft = this._scrollLeft;
+        } else {
+          // Since we don't know if is the body or html, set both.
+          document.documentElement.scrollTop = this._scrollTop;
+          document.documentElement.scrollLeft = this._scrollLeft;
+          document.body.scrollTop = this._scrollTop;
+          document.body.scrollLeft = this._scrollLeft;
+        }
       }
     };
   })();

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -19,9 +19,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       pageX: 0,
       pageY: 0
     };
-    // Memoized event path for better perf. For touch events, it gets saved on
-    // touchstart and consumed during touchmove.
-    var EVENT_PATH = [];
+    // Memoize target and scrollable nodes for better perf.
+    var PREVIOUS_TARGET = null;
+    var SCROLLABLE_NODES = [];
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
@@ -165,7 +165,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.addEventListener('mousewheel', this._boundScrollHandler, true);
         // IE:
         document.addEventListener('DOMMouseScroll', this._boundScrollHandler, true);
-        // Save the EVENT_PATH on touchstart, to be used on touchmove.
+        // Save the SCROLLABLE_NODES on touchstart, to be used on touchmove.
         document.addEventListener('touchstart', this._boundScrollHandler, true);
         // Mobile devices can scroll on touch move:
         document.addEventListener('touchmove', this._boundScrollHandler, true);
@@ -204,14 +204,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Update if root target changed. For touch events, ensure we don't
         // update during touchmove.
-        if (event.type !== 'touchmove' &&
-          EVENT_PATH[0] !== Polymer.dom(event).rootTarget) {
-          EVENT_PATH = Polymer.dom(event).path;
+        var target = Polymer.dom(event).rootTarget;
+        if (event.type !== 'touchmove' && PREVIOUS_TARGET !== target) {
+          PREVIOUS_TARGET = target;
+          SCROLLABLE_NODES = this._getScrollableNodes(Polymer.dom(event).path);
         }
 
-        var lockingIndex = EVENT_PATH.indexOf(this.currentLockingElement);
-        // Prevent event dispatched by an element outside the locking element.
-        if (lockingIndex < 0) {
+        // Prevent event if no scrollable nodes.
+        if (!SCROLLABLE_NODES.length) {
           return true;
         }
         // Don't prevent touchstart events inside the locking element.
@@ -219,47 +219,85 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return false;
         }
 
-        // Get deltaX/Y info.
-        var info = this._getScrollDeltaInfo(event);
-
-        // Prevent if there is no child inside locking element that can scroll.
-        var shouldPrevent = true;
-        // Check either vertical or horizontal, according to where
-        // there was more scroll. Prefer vertical over horizontal.
-        var verticalScroll = Math.abs(info.deltaY) >= Math.abs(info.deltaX);
-        // Loop from root target to locking element (included).
-        for (var i = 0; i <= lockingIndex; i++) {
-          var node = EVENT_PATH[i];
-          var canScroll = false;
-          if (verticalScroll) {
-            // delta < 0 = scroll up, else scroll down.
-            canScroll = info.deltaY < 0 ? node.scrollTop > 0 :
-              node.scrollTop < node.scrollHeight - node.clientHeight;
-          } else {
-            // delta < 0 = scroll left, else scroll right.
-            canScroll = info.deltaX < 0 ? node.scrollLeft > 0 :
-              node.scrollLeft < node.scrollWidth - node.clientWidth;
-          }
-          // If it can scroll, don't prevent.
-          if (canScroll) {
-            shouldPrevent = false;
-            break;
-          }
-        }
-        return shouldPrevent;
+        // Get deltaX/Y.
+        var info = this._getScrollInfo(event);
+        // Prevent if there is no child that can scroll.
+        return !this._getScrollingNode(SCROLLABLE_NODES, info.vertical, info.delta);
       },
 
       /**
-       * Returns `deltaX` and `deltaY` of the event normalized cross-browsers.
+       * Returns an array of scrollable nodes up to currentLockingElement.
+       * @param {!Array<Node>} nodes
+       * @return {Array<Node>} scrollables
+       * @private
+       */
+      _getScrollableNodes: function(nodes) {
+        var scrollables = [];
+        var lockingIndex = nodes.indexOf(this.currentLockingElement);
+        for (var i = 0; i <= lockingIndex; i++) {
+          var node = nodes[i];
+          // Skip document fragments.
+          if (node.nodeType === 11) {
+            continue;
+          }
+          // Check inline style before checking computed style.
+          var style = node.style;
+          if (style.overflow !== 'scroll' && style.overflow !== 'auto') {
+            style = window.getComputedStyle(node);
+          }
+          if (style.overflow === 'scroll' || style.overflow === 'auto') {
+            scrollables.push(node);
+          }
+
+        }
+        return scrollables;
+      },
+
+      /**
+       * Returns the node that is scrolling.
+       * @param {!Array<Node>} nodes
+       * @param {boolean} verticalScroll True if scrollDelta is applied vertically.
+       * @param {number} scrollDelta Negative value means scroll up/left,
+       *  positive value means down/right.
+       * @return {Node|undefined}
+       * @private
+       */
+      _getScrollingNode: function(nodes, verticalScroll, scrollDelta) {
+        // Loop from root target to locking element (included).
+        for (var i = 0; i < nodes.length; i++) {
+          var node = nodes[i];
+          var canScroll = false;
+          if (verticalScroll) {
+            // delta < 0 = scroll up, else scroll down.
+            canScroll = scrollDelta < 0 ? node.scrollTop > 0 :
+              node.scrollTop < node.scrollHeight - node.clientHeight;
+          } else {
+            // delta < 0 = scroll left, else scroll right.
+            canScroll = scrollDelta < 0 ? node.scrollLeft > 0 :
+              node.scrollLeft < node.scrollWidth - node.clientWidth;
+          }
+          if (canScroll) {
+            return node;
+          }
+        }
+      },
+
+      /**
+       * Returns scroll info like `deltaX` `deltaY` of the event normalized
+       * cross-browsers, `delta` and `vertical`.
+       *
        * Positive value: scroll down/right
        * Negative value: scroll up/left.
        * @param {!Event} event The scroll event
        * @return {{
-       *  deltaX: number,
-       *  deltaY: number}} info
+       *  deltaX:   number Scroll delta on the x-axis,
+       *  deltaY:   number Scroll delta on the y-axis,
+       *  delta:    number Dominant scroll delta (see `vertical`),
+       *  vertical: boolean If the vertical axis is scrolling more than the
+       *            horizontal axis}} info
        * @private
        */
-      _getScrollDeltaInfo: function(event) {
+      _getScrollInfo: function(event) {
         var info = {
           deltaX: event.deltaX,
           deltaY: event.deltaY
@@ -284,6 +322,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           info.deltaX = touch.pageX - PREVIOUS_TOUCH.pageX;
           info.deltaY = PREVIOUS_TOUCH.pageY - touch.pageY;
         }
+        // vertical or horizontal, according to where there is more scroll.
+        // Prefer vertical over horizontal.
+        info.vertical = Math.abs(info.deltaY) >= Math.abs(info.deltaX);
+        info.delta = info.vertical ? info.deltaY : info.deltaX;
         return info;
       }
     };

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -47,39 +47,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return false;
         }
 
-        var currentLockingElement = this.currentLockingElement;
-        if (currentLockingElement === undefined) {
+        var lockingElement = this.currentLockingElement;
+        if (!lockingElement) {
           return false;
         }
 
-        var xDelta = event.wheelDeltaX;
-        var yDelta = event.wheelDeltaY;
-        if (event.type === 'touchmove' && lastTouch) {
-          xDelta = lastTouch.pageX - event.pageX;
-          yDelta = event.pageY - lastTouch.pageY;
-        }
+        // Makes sure deltaX/Y are set.
+        this._normalizeWheelDelta(event);
 
-        var nodes = Polymer.dom(event).path;
-        var lockingIndex = nodes.indexOf(currentLockingElement);
+        var eventPath = Polymer.dom(event).path;
+        var lockingIndex = eventPath.indexOf(lockingElement);
         // Search for one scrollable that can still scroll, stop at the locked element.
         for (var i = 0; i < lockingIndex; i++) {
-          var node = nodes[i];
+          var node = eventPath[i];
 
           // Check either vertical or horizontal, according to where
           // there was more scroll.
           var scrollDelta, scrollableSize, scrollPos;
-          if (Math.abs(yDelta) >= Math.abs(xDelta)) {
-            scrollDelta = yDelta;
+          if (Math.abs(event.deltaY) >= Math.abs(event.deltaX)) {
+            scrollDelta = event.deltaY;
             scrollableSize = node.scrollHeight - node.clientHeight;
             scrollPos = node.scrollTop;
           } else {
-            scrollDelta = xDelta;
+            scrollDelta = event.deltaX;
             scrollableSize = node.scrollWidth - node.clientWidth;
             scrollPos = node.scrollLeft;
           }
           // If it can scroll, don't prevent.
           if (scrollDelta !== 0 && scrollableSize > 0 &&
-              (scrollDelta > 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
+            (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
             return false;
           }
         }
@@ -168,8 +164,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
+      },
+
+      /**
+       * Normalizes `deltaX` and `deltaY` of the wheel event.
+       * Positive value: scroll down/right
+       * Negative value: scroll up/left.
+       * @private
+       */
+      _normalizeWheelDelta: function(event) {
+        // Already set, return.
+        if (event.deltaX || event.deltaY) {
+          return;
+        }
+        // Safari has scroll info in `wheelDeltaX/Y`.
+        if (event.wheelDeltaX || event.wheelDeltaY) {
+          event.deltaX = -event.wheelDeltaX;
+          event.deltaY = -event.wheelDeltaY;
+        }
+        // Firefox has scroll info in `detail` and `axis`.
+        else if (event.axis) {
+          event.deltaX = event.axis === 1 ? event.detail : 0;
+          event.deltaY = event.axis === 2 ? event.detail : 0;
+        }
+        // Mobile devices, must calculate the scroll direction.
+        else if (event.type === 'touchmove' && lastTouch) {
+          event.deltaX = event.pageX - lastTouch.pageX;
+          event.deltaY = lastTouch.pageY - event.pageY;
+        }
       }
     };
   })();
-
 </script>

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -15,7 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
     // Used to calculate the scroll direction.
-    var lastTouch = null;
+    var PREV_EVENT = null;
+    var EVENT_PATH = [];
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
@@ -35,8 +36,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
       /**
-       * Returns true if the element causing the scroll is "scroll locked," which is to
-       * say that it cannot be scrolled via pointer or keyboard interactions, or
+       * Returns true if the element causing the scroll is "scroll locked",
+       * meaning it cannot be scrolled via pointer or keyboard interactions, or
        * if already at its scroll boundaries.
        *
        * @param {Event} event The scroll event
@@ -55,32 +56,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Makes sure deltaX/Y are set.
         this._normalizeWheelDelta(event);
+        // No scrolling.
+        if (!event.deltaX && !event.deltaY) {
+          return false;
+        }
+        // Check either vertical or horizontal, according to where
+        // there was more scroll.
+        var scrollDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ?
+          event.deltaY : event.deltaX;
 
-        var eventPath = Polymer.dom(event).path;
-        var lockingIndex = eventPath.indexOf(lockingElement);
+        // Check if EVENT_PATH needs to be updated. For touch events rely on the
+        // `EVENT_PATH` saved on touchstart.
+        if (event.type !== 'touchmove') {
+          EVENT_PATH = Polymer.dom(event).path;
+        }
+        var lockingIndex = EVENT_PATH.indexOf(lockingElement);
         // Search for one scrollable that can still scroll, stop at the locked element.
         for (var i = 0; i < lockingIndex; i++) {
-          var node = eventPath[i];
-
-          // Check either vertical or horizontal, according to where
-          // there was more scroll.
-          var scrollDelta, scrollableSize, scrollPos;
-          if (Math.abs(event.deltaY) >= Math.abs(event.deltaX)) {
-            scrollDelta = event.deltaY;
-            scrollableSize = node.scrollHeight - node.clientHeight;
-            scrollPos = node.scrollTop;
-          } else {
-            scrollDelta = event.deltaX;
-            scrollableSize = node.scrollWidth - node.clientWidth;
-            scrollPos = node.scrollLeft;
-          }
+          var node = EVENT_PATH[i];
+          var scrollableSize = scrollDelta === event.deltaY ?
+            node.scrollHeight - node.clientHeight : node.scrollWidth - node.clientWidth;
+          var scrollPos = scrollDelta === event.deltaY ? node.scrollTop : node.scrollLeft;
           // If it can scroll, don't prevent.
-          if (scrollDelta !== 0 && scrollableSize > 0 &&
-            (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
+          if (scrollableSize > 0 && (scrollDelta < 0 ? scrollPos > 0 : scrollPos < scrollableSize)) {
             return false;
           }
         }
-        // Don't prevent if event's target is currentLockingElement.
+        // Don't prevent if event's target is the current locking element.
         return lockingIndex !== 0;
       },
 
@@ -132,6 +134,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _lockingElements: [],
 
+      _touchstartHandler: function(event) {
+        // Memoize it, since on mobile the scroll gesture might happen outside
+        // the element initially touched.
+        EVENT_PATH = Polymer.dom(event).path;
+      },
+
       _isScrollingKeypress: function(event) {
         return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(
           event, 'pageup pagedown home end up left down right');
@@ -141,7 +149,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (Polymer.IronDropdownScrollManager.shouldPreventScrolling(event)) {
           event.preventDefault();
         }
-        lastTouch = event;
+        PREV_EVENT = event;
       },
 
       _lockScrollInteractions: function() {
@@ -151,6 +159,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.addEventListener('mousewheel', this._scrollInteractionHandler, true);
         // IE:
         document.addEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
+        // Save the EVENT_PATH on touchstart, to be used on touchmove.
+        document.addEventListener('touchstart', this._touchstartHandler, true);
         // Mobile devices can scroll on touch move:
         document.addEventListener('touchmove', this._scrollInteractionHandler, true);
         // Capture keydown to prevent scrolling keys (pageup, pagedown etc.)
@@ -161,6 +171,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
+        document.removeEventListener('touchstart', this._touchstartHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
       },
@@ -187,9 +198,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           event.deltaY = event.axis === 2 ? event.detail : 0;
         }
         // Mobile devices, must calculate the scroll direction.
-        else if (event.type === 'touchmove' && lastTouch) {
-          event.deltaX = event.pageX - lastTouch.pageX;
-          event.deltaY = lastTouch.pageY - event.pageY;
+        else if (event.type === 'touchmove' && PREV_EVENT) {
+          event.deltaX = event.pageX - PREV_EVENT.pageX;
+          event.deltaY = PREV_EVENT.pageY - event.pageY;
         }
       }
     };

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         scrollLocked = !!currentLockingElement &&
           currentLockingElement !== element &&
-          !Polymer.dom(currentLockingElement).deepContains(element);
+          !this._composedTreeContains(currentLockingElement, element);
 
         if (scrollLocked) {
           this._lockedElementCache.push(element);
@@ -125,7 +125,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this._lockingElements.length === 0) {
           this._unlockScrollInteractions();
         }
-
       },
 
       _lockingElements: [],
@@ -145,6 +144,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _hasCachedUnlockedElement: function(element) {
         return this._unlockedElementCache.indexOf(element) > -1;
+      },
+
+      _composedTreeContains: function(element, child) {
+        // NOTE(cdata): This method iterates over content elements and their
+        // corresponding distributed nodes to implement a contains-like method
+        // that pierces through the composed tree of the ShadowDOM. Results of
+        // this operation are cached (elsewhere) on a per-scroll-lock basis, to
+        // guard against potentially expensive lookups happening repeatedly as
+        // a user scrolls / touchmoves.
+        var contentElements;
+        var distributedNodes;
+        var contentIndex;
+        var nodeIndex;
+
+        if (element.contains(child)) {
+          return true;
+        }
+
+        contentElements = Polymer.dom(element).querySelectorAll('content');
+
+        for (contentIndex = 0; contentIndex < contentElements.length; ++contentIndex) {
+
+          distributedNodes = Polymer.dom(contentElements[contentIndex]).getDistributedNodes();
+
+          for (nodeIndex = 0; nodeIndex < distributedNodes.length; ++nodeIndex) {
+
+            if (this._composedTreeContains(distributedNodes[nodeIndex], child)) {
+              return true;
+            }
+          }
+        }
+
+        return false;
       },
 
       _scrollInteractionHandler: function(event) {
@@ -268,14 +300,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!deltaX && !deltaY) {
           return;
         }
+        // Check only one axis according to where there is more scroll.
+        // Prefer vertical to horizontal.
+        var verticalScroll = Math.abs(deltaY) >= Math.abs(deltaX);
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];
-          // delta < 0 is scroll up, delta > 0 is scroll down.
-          var canScroll = (deltaY < 0 && node.scrollTop > 0) ||
-            (deltaY > 0 && node.scrollTop < node.scrollHeight - node.clientHeight);
-          // delta < 0 is scroll left, delta > 0 is scroll right.
-          canScroll = canScroll || (deltaX < 0 && node.scrollLeft > 0) ||
-            (deltaX > 0 && node.scrollLeft < node.scrollWidth - node.clientWidth);
+          var canScroll = false;
+          if (verticalScroll) {
+            // delta < 0 is scroll up, delta > 0 is scroll down.
+            canScroll = deltaY < 0 ? node.scrollTop > 0 :
+              node.scrollTop < node.scrollHeight - node.clientHeight;
+          } else {
+            // delta < 0 is scroll left, delta > 0 is scroll right.
+            canScroll = deltaX < 0 ? node.scrollLeft > 0 :
+              node.scrollLeft < node.scrollWidth - node.clientWidth;
+          }
           if (canScroll) {
             return node;
           }
@@ -299,16 +338,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           deltaY: event.deltaY
         };
         // Already available.
-        if (event.deltaX || event.deltaY) {
+        if ('deltaX' in event) {
           // do nothing, values are already good.
         }
         // Safari has scroll info in `wheelDeltaX/Y`.
-        else if (event.wheelDeltaX || event.wheelDeltaY) {
+        else if ('wheelDeltaX' in event) {
           info.deltaX = -event.wheelDeltaX;
           info.deltaY = -event.wheelDeltaY;
         }
         // Firefox has scroll info in `detail` and `axis`.
-        else if (event.axis) {
+        else if ('axis' in event) {
           info.deltaX = event.axis === 1 ? event.detail : 0;
           info.deltaY = event.axis === 2 ? event.detail : 0;
         }

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -150,10 +150,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _lockScrollInteractions: function() {
-        // Memoize body scroll position
-        this._saveScrollPosition();
-        document.addEventListener('scroll', this._restoreScrollPosition, true);
-
         // Modern `wheel` event for mouse wheel scrolling:
         document.addEventListener('wheel', this._scrollInteractionHandler, true);
         // Older, non-standard `mousewheel` event for some FF:
@@ -167,44 +163,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _unlockScrollInteractions: function() {
-        document.removeEventListener('scroll', this._restoreScrollPosition, true);
         document.removeEventListener('wheel', this._scrollInteractionHandler, true);
         document.removeEventListener('mousewheel', this._scrollInteractionHandler, true);
         document.removeEventListener('DOMMouseScroll', this._scrollInteractionHandler, true);
         document.removeEventListener('touchmove', this._scrollInteractionHandler, true);
         document.removeEventListener('keydown', this._scrollInteractionHandler, true);
-      },
-
-      /**
-       * Memoizes the scroll position of the outside scrolling element.
-       * @private
-       */
-      _saveScrollPosition: function() {
-        if (document.scrollingElement) {
-          this._scrollTop = document.scrollingElement.scrollTop;
-          this._scrollLeft = document.scrollingElement.scrollLeft;
-        } else {
-          // Since we don't know if is the body or html, get max.
-          this._scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
-          this._scrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
-        }
-      },
-
-      /**
-       * Resets the scroll position of the outside scrolling element.
-       * @private
-       */
-      _restoreScrollPosition: function() {
-        if (document.scrollingElement) {
-          document.scrollingElement.scrollTop = this._scrollTop;
-          document.scrollingElement.scrollLeft = this._scrollLeft;
-        } else {
-          // Since we don't know if is the body or html, set both.
-          document.documentElement.scrollTop = this._scrollTop;
-          document.documentElement.scrollLeft = this._scrollLeft;
-          document.body.scrollTop = this._scrollTop;
-          document.body.scrollLeft = this._scrollLeft;
-        }
       }
     };
   })();

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -14,13 +14,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   (function() {
     'use strict';
-    // Used to calculate the scroll direction.
-    var PREVIOUS_TOUCH = {
+    // Used to calculate the scroll direction during touch events.
+    var LAST_TOUCH_POSITION = {
       pageX: 0,
       pageY: 0
     };
-    // Memoize target and scrollable nodes for better perf.
-    var PREVIOUS_TARGET = null;
+    // Used to avoid computing event.path and filter scrollable nodes (better perf).
+    var ROOT_TARGET = null;
     var SCROLLABLE_NODES = [];
 
     /**
@@ -148,12 +148,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _scrollInteractionHandler: function(event) {
-        if (this._shouldPreventScrolling(event)) {
+        // Avoid canceling an event with cancelable=false, e.g. scrolling is in
+        // progress and cannot be interrupted.
+        if (event.cancelable && this._shouldPreventScrolling(event)) {
           event.preventDefault();
         }
-        var touch = this._getTouchFromEvent(event);
-        PREVIOUS_TOUCH.pageX = touch.pageX;
-        PREVIOUS_TOUCH.pageY = touch.pageY;
+        // If event has targetTouches (touch event), update last touch position.
+        if (event.targetTouches) {
+          var touch = event.targetTouches[0];
+          LAST_TOUCH_POSITION.pageX = touch.pageX;
+          LAST_TOUCH_POSITION.pageY = touch.pageY;
+        }
       },
 
       _lockScrollInteractions: function() {
@@ -182,25 +187,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.removeEventListener('keydown', this._boundScrollHandler, true);
       },
 
-      _getTouchFromEvent: function(event) {
-        return event.targetTouches ? event.targetTouches[0] : event;
-      },
-
       /**
        * Returns true if the event causes scroll outside the current locking
-       * element, e.g. pointer or keyboard interactions, or scroll "leaking"
+       * element, e.g. pointer/keyboard interactions, or scroll "leaking"
        * outside the locking element when it is already at its scroll boundaries.
-       *
-       * @param {!Event} event The scroll event
+       * @param {!Event} event
        * @return {boolean}
        * @private
        */
       _shouldPreventScrolling: function(event) {
-        // Avoid canceling an event with cancelable=false, e.g. scrolling is in
-        // progress and cannot be interrupted.
-        if (!event.cancelable) {
-          return false;
-        }
         // Avoid expensive checks if the event is not one of the observed keys.
         if (event.type === 'keydown') {
           // Prevent event if it is one of the scrolling keys.
@@ -210,8 +205,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Update if root target changed. For touch events, ensure we don't
         // update during touchmove.
         var target = Polymer.dom(event).rootTarget;
-        if (event.type !== 'touchmove' && PREVIOUS_TARGET !== target) {
-          PREVIOUS_TARGET = target;
+        if (event.type !== 'touchmove' && ROOT_TARGET !== target) {
+          ROOT_TARGET = target;
           SCROLLABLE_NODES = this._getScrollableNodes(Polymer.dom(event).path);
         }
 
@@ -219,19 +214,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!SCROLLABLE_NODES.length) {
           return true;
         }
-        // Don't prevent touchstart events inside the locking element.
+        // Don't prevent touchstart event inside the locking element when it has
+        // scrollable nodes.
         if (event.type === 'touchstart') {
           return false;
         }
-
         // Get deltaX/Y.
         var info = this._getScrollInfo(event);
         // Prevent if there is no child that can scroll.
-        return !this._getScrollingNode(SCROLLABLE_NODES, info.vertical, info.delta);
+        return !this._getScrollingNode(SCROLLABLE_NODES, info.deltaX, info.deltaY);
       },
 
       /**
-       * Returns an array of scrollable nodes up to currentLockingElement.
+       * Returns an array of scrollable nodes up to the current locking element,
+       * which is included too if scrollable.
        * @param {!Array<Node>} nodes
        * @return {Array<Node>} scrollables
        * @private
@@ -239,6 +235,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _getScrollableNodes: function(nodes) {
         var scrollables = [];
         var lockingIndex = nodes.indexOf(this.currentLockingElement);
+        // Loop from root target to locking element (included).
         for (var i = 0; i <= lockingIndex; i++) {
           var node = nodes[i];
           // Skip document fragments.
@@ -253,34 +250,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (style.overflow === 'scroll' || style.overflow === 'auto') {
             scrollables.push(node);
           }
-
         }
         return scrollables;
       },
 
       /**
-       * Returns the node that is scrolling.
+       * Returns the node that is scrolling. If there is no scrolling,
+       * returns undefined.
        * @param {!Array<Node>} nodes
-       * @param {boolean} verticalScroll True if scrollDelta is applied vertically.
-       * @param {number} scrollDelta Negative value means scroll up/left,
-       *  positive value means down/right.
+       * @param {number} deltaX Scroll delta on the x-axis
+       * @param {number} deltaY Scroll delta on the y-axis
        * @return {Node|undefined}
        * @private
        */
-      _getScrollingNode: function(nodes, verticalScroll, scrollDelta) {
-        // Loop from root target to locking element (included).
+      _getScrollingNode: function(nodes, deltaX, deltaY) {
+        // No scroll.
+        if (!deltaX && !deltaY) {
+          return;
+        }
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];
-          var canScroll = false;
-          if (verticalScroll) {
-            // delta < 0 = scroll up, else scroll down.
-            canScroll = scrollDelta < 0 ? node.scrollTop > 0 :
-              node.scrollTop < node.scrollHeight - node.clientHeight;
-          } else {
-            // delta < 0 = scroll left, else scroll right.
-            canScroll = scrollDelta < 0 ? node.scrollLeft > 0 :
-              node.scrollLeft < node.scrollWidth - node.clientWidth;
-          }
+          // delta < 0 is scroll up, delta > 0 is scroll down.
+          var canScroll = (deltaY < 0 && node.scrollTop > 0) ||
+            (deltaY > 0 && node.scrollTop < node.scrollHeight - node.clientHeight);
+          // delta < 0 is scroll left, delta > 0 is scroll right.
+          canScroll = canScroll || (deltaX < 0 && node.scrollLeft > 0) ||
+            (deltaX > 0 && node.scrollLeft < node.scrollWidth - node.clientWidth);
           if (canScroll) {
             return node;
           }
@@ -288,18 +283,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Returns scroll info like `deltaX` `deltaY` of the event normalized
-       * cross-browsers, `delta` and `vertical`.
-       *
-       * Positive value: scroll down/right
-       * Negative value: scroll up/left.
+       * Returns scroll `deltaX` and `deltaY`.
        * @param {!Event} event The scroll event
        * @return {{
-       *  deltaX:   number Scroll delta on the x-axis,
-       *  deltaY:   number Scroll delta on the y-axis,
-       *  delta:    number Dominant scroll delta (see `vertical`),
-       *  vertical: boolean If the vertical axis is scrolling more than the
-       *            horizontal axis}} info
+       *  deltaX: number The x-axis scroll delta (positive: scroll right,
+       *                 negative: scroll left, 0: no scroll),
+       *  deltaY: number The y-axis scroll delta (positive: scroll down,
+       *                 negative: scroll up, 0: no scroll)
+       * }} info
        * @private
        */
       _getScrollInfo: function(event) {
@@ -322,15 +313,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           info.deltaY = event.axis === 2 ? event.detail : 0;
         }
         // On mobile devices, calculate scroll direction.
-        else {
-          var touch = this._getTouchFromEvent(event);
-          info.deltaX = touch.pageX - PREVIOUS_TOUCH.pageX;
-          info.deltaY = PREVIOUS_TOUCH.pageY - touch.pageY;
+        else if (event.targetTouches) {
+          var touch = event.targetTouches[0];
+          // Touch moves from right to left => scrolling goes right.
+          info.deltaX = LAST_TOUCH_POSITION.pageX - touch.pageX;
+          // Touch moves from down to up => scrolling goes down.
+          info.deltaY = LAST_TOUCH_POSITION.pageY - touch.pageY;
         }
-        // vertical or horizontal, according to where there is more scroll.
-        // Prefer vertical over horizontal.
-        info.vertical = Math.abs(info.deltaY) >= Math.abs(info.deltaX);
-        info.delta = info.vertical ? info.deltaY : info.deltaX;
         return info;
       }
     };

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -16,6 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     'use strict';
     // Used to calculate the scroll direction.
     var PREV_EVENT = null;
+    // Memoized event path for better perf. For touch events, it gets saved on
+    // touchstart and consumed during touchmove.
     var EVENT_PATH = [];
 
     /**
@@ -143,11 +145,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _scrollInteractionHandler: function(event) {
-        if (event.type === 'touchstart') {
-          // Memoize it, since on mobile the scroll gesture might happen outside
-          // the element initially touched.
-          EVENT_PATH = Polymer.dom(event).path;
-        }
         if (this._shouldPreventScrolling(event)) {
           event.preventDefault();
         }
@@ -190,57 +187,65 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @private
        */
       _shouldPreventScrolling: function(event) {
-        var lockingElement = this.currentLockingElement;
-        if (!lockingElement) {
-          return false;
-        }
         // Avoid expensive checks if the event is not one of the observed keys.
         if (event.type === 'keydown') {
           // Prevent event if it is one of the scrolling keys.
           return this._isScrollingKeypress(event);
         }
 
-        // Makes sure deltaX/Y are set.
-        this._normalizeWheelDelta(event);
-
-        // Check either vertical or horizontal, according to where
-        // there was more scroll.
-        var isScrollVertical = Math.abs(event.deltaY) >= Math.abs(event.deltaX);
-        // delta < 0 = scroll up, delta > 0 = scroll down.
-        var isScrollUp = isScrollVertical ? event.deltaY < 0 : event.deltaX < 0;
-
-        // EVENT_PATH is memoized for better perf and updated if needed.
-        // For touch events rely on the EVENT_PATH saved on touchstart.
+        // Update if root target changed. For touch events, ensure we don't
+        // update during touchmove.
         if (event.type !== 'touchmove' &&
           EVENT_PATH[0] !== Polymer.dom(event).rootTarget) {
           EVENT_PATH = Polymer.dom(event).path;
         }
-        // Search for one scrollable that can still scroll up to locked element.
-        var lockingIndex = EVENT_PATH.indexOf(lockingElement);
-        var i, node, canScroll;
-        for (i = 0; i < lockingIndex; i++) {
-          node = EVENT_PATH[i];
-          canScroll = false;
+
+        var lockingIndex = EVENT_PATH.indexOf(this.currentLockingElement);
+        // Prevent event dispatched by an element outside the locking element,
+        // don't prevent event dispatched by the locking element.
+        if (lockingIndex <= 0) {
+          return lockingIndex < 0;
+        }
+
+        // Makes sure deltaX/Y are set.
+        this._normalizeWheelDelta(event);
+        // If no scroll (e.g. on touchstart), don't prevent.
+        if (!event.deltaX && !event.deltaY) {
+          return false;
+        }
+
+        // Prevent if there is no child inside locking element that can scroll.
+        var shouldPrevent = true;
+        // Check either vertical or horizontal, according to where
+        // there was more scroll. Prefer vertical over horizontal.
+        var isScrollVertical = Math.abs(event.deltaY) >= Math.abs(event.deltaX);
+        // Loop from root target to locking element (excluded).
+        for (var i = 0; i < lockingIndex; i++) {
+          var node = EVENT_PATH[i];
+          var canScroll = false;
           if (isScrollVertical) {
-            canScroll = isScrollUp ? node.scrollTop > 0 :
+            // delta < 0 = scroll up, else scroll down.
+            canScroll = event.deltaY < 0 ? node.scrollTop > 0 :
               node.scrollTop < node.scrollHeight - node.clientHeight;
           } else {
-            canScroll = isScrollUp ? node.scrollLeft > 0 :
+            // delta < 0 = scroll left, else scroll right.
+            canScroll = event.deltaX < 0 ? node.scrollLeft > 0 :
               node.scrollLeft < node.scrollWidth - node.clientWidth;
           }
           // If it can scroll, don't prevent.
           if (canScroll) {
-            return false;
+            shouldPrevent = false;
+            break;
           }
         }
-        // Don't prevent if event's target is the current locking element.
-        return lockingIndex !== 0;
+        return shouldPrevent;
       },
 
       /**
-       * Normalizes `deltaX` and `deltaY` of the wheel event.
+       * Normalizes `deltaX` and `deltaY` of the event.
        * Positive value: scroll down/right
        * Negative value: scroll up/left.
+       * @param {!Event} event The scroll event
        * @private
        */
       _normalizeWheelDelta: function(event) {

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -143,6 +143,18 @@ method is called on the element.
           allowOutsideScroll: {
             type: Boolean,
             value: false
+          },
+
+          /**
+           * Callback for scroll events.
+           * @type {Function}
+           * @private
+           */
+          _boundOnCaptureScroll: {
+            type: Function,
+            value: function() {
+              return this._onCaptureScroll.bind(this);
+            }
           }
         },
 
@@ -169,6 +181,14 @@ method is called on the element.
           return this.focusTarget || this.containedElement;
         },
 
+        ready: function() {
+          // Memoized scrolling position, used to block scrolling outside.
+          this._scrollTop = 0;
+          this._scrollLeft = 0;
+          // Used to perform a non-blocking refit on scroll.
+          this._refitOnScrollRAF = null;
+        },
+
         detached: function() {
           this.cancelAnimation();
           Polymer.IronDropdownScrollManager.removeScrollLock(this);
@@ -185,9 +205,12 @@ method is called on the element.
             this.cancelAnimation();
             this.sizingTarget = this.containedElement || this.sizingTarget;
             this._updateAnimationConfig();
-            if (this.opened && !this.allowOutsideScroll) {
-              Polymer.IronDropdownScrollManager.pushScrollLock(this);
+            this._saveScrollPosition();
+            if (this.opened) {
+              document.addEventListener('scroll', this._boundOnCaptureScroll);
+              !this.allowOutsideScroll && Polymer.IronDropdownScrollManager.pushScrollLock(this);
             } else {
+              document.removeEventListener('scroll', this._boundOnCaptureScroll);
               Polymer.IronDropdownScrollManager.removeScrollLock(this);
             }
             Polymer.IronOverlayBehaviorImpl._openedChanged.apply(this, arguments);
@@ -210,6 +233,7 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderClosed: function() {
+
           if (!this.noAnimations && this.animationConfig.close) {
             this.$.contentWrapper.classList.add('animating');
             this.playAnimation('close');
@@ -230,6 +254,47 @@ method is called on the element.
             this._finishRenderOpened();
           } else {
             this._finishRenderClosed();
+          }
+        },
+
+        _onCaptureScroll: function() {
+          if (!this.allowOutsideScroll) {
+            this._restoreScrollPosition();
+          } else {
+            this._refitOnScrollRAF && window.cancelAnimationFrame(this._refitOnScrollRAF);
+            this._refitOnScrollRAF = window.requestAnimationFrame(this.refit.bind(this));
+          }
+        },
+
+        /**
+         * Memoizes the scroll position of the outside scrolling element.
+         * @private
+         */
+        _saveScrollPosition: function() {
+          if (document.scrollingElement) {
+            this._scrollTop = document.scrollingElement.scrollTop;
+            this._scrollLeft = document.scrollingElement.scrollLeft;
+          } else {
+            // Since we don't know if is the body or html, get max.
+            this._scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+            this._scrollLeft = Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);
+          }
+        },
+
+        /**
+         * Resets the scroll position of the outside scrolling element.
+         * @private
+         */
+        _restoreScrollPosition: function() {
+          if (document.scrollingElement) {
+            document.scrollingElement.scrollTop = this._scrollTop;
+            document.scrollingElement.scrollLeft = this._scrollLeft;
+          } else {
+            // Since we don't know if is the body or html, set both.
+            document.documentElement.scrollTop = this._scrollTop;
+            document.documentElement.scrollLeft = this._scrollLeft;
+            document.body.scrollTop = this._scrollTop;
+            document.body.scrollLeft = this._scrollLeft;
           }
         },
 

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -31,12 +31,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
   <script>
+
+    function fireWheel(node, deltaX, deltaY) {
+      // IE 11 doesn't support WheelEvent, use CustomEvent.
+      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      node.dispatchEvent(event);
+      return event;
+    }
+
     suite('IronDropdownScrollManager', function() {
       var parent;
       var childOne;
       var childTwo;
-      var grandchildOne;
-      var grandchildTwo;
+      var grandChildOne;
+      var grandChildTwo;
       var ancestor;
 
       setup(function() {
@@ -58,57 +66,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childTwo))
-            .to.be.equal(true);
+          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildTwo))
-            .to.be.equal(true);
+          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
-            .to.be.equal(true);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(ancestor))
-            .to.be.equal(true);
+          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childOne))
-            .to.be.equal(false);
+          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildOne))
-            .to.be.equal(false);
+          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
-            .to.be.equal(false);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('does not check locked elements when there are no locking elements', function() {
-          sinon.spy(Polymer.IronDropdownScrollManager, 'elementIsScrollLocked');
-          childOne.dispatchEvent(new CustomEvent('wheel', {
-            bubbles: true,
-            cancelable: true
-          }));
+          sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
-              .elementIsScrollLocked.callCount).to.be.eql(1);
+              .shouldPreventScrolling.callCount).to.be.eql(1);
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          childOne.dispatchEvent(new CustomEvent('wheel', {
-            bubbles: true,
-            cancelable: true
-          }));
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
-              .elementIsScrollLocked.callCount).to.be.eql(1);
+              .shouldPreventScrolling.callCount).to.be.eql(1);
         });
 
         suite('various scroll events', function() {

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -9,6 +9,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>iron-dropdown-scroll-manager tests</title>
@@ -23,6 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="x-scrollable-element.html">
 </head>
+
 <body>
 
   <test-fixture id="DOMSubtree">
@@ -31,15 +33,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
   <script>
-
-    function fireWheel(node, deltaX, deltaY) {
-      // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
-      event.deltaX = deltaX;
-      event.deltaY = deltaY;
-      node.dispatchEvent(event);
-      return event;
-    }
 
     suite('IronDropdownScrollManager', function() {
       var parent;
@@ -68,44 +61,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childTwo))
+            .to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildTwo))
+            .to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
+            .to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(ancestor))
+            .to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(childOne))
+            .to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(grandChildOne))
+            .to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
-        });
-
-        test('does not check locked elements when there are no locking elements', function() {
-          sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
-          fireWheel(childOne, 0, 10);
-          expect(Polymer.IronDropdownScrollManager
-              .shouldPreventScrolling.callCount).to.be.eql(1);
-          Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          fireWheel(childOne, 0, 10);
-          expect(Polymer.IronDropdownScrollManager
-              .shouldPreventScrolling.callCount).to.be.eql(1);
+          expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(parent))
+            .to.be.equal(false);
         });
 
         suite('various scroll events', function() {
@@ -138,6 +127,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
           });
 
+          test('allows wheel events when there are no locking elements', function() {
+            Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
+            events.forEach(function(event) {
+              childTwo.dispatchEvent(event);
+              expect(event.defaultPrevented).to.be.eql(false);
+            });
+          });
+
           test('allows wheel events from unlocked elements', function() {
             events.forEach(function(event) {
               childOne.dispatchEvent(event);
@@ -149,4 +146,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </body>
+
 </html>

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -141,6 +141,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(event.defaultPrevented).to.be.eql(false);
             });
           });
+
+          test('touchstart is prevented if dispatched by an element outside the locking element', function() {
+            var event = new CustomEvent('touchstart', {
+              bubbles: true,
+              cancelable: true
+            });
+            childTwo.dispatchEvent(event);
+            expect(event.defaultPrevented).to.be.eql(true);
+          });
+
+          test('touchstart is not prevented if dispatched by an element inside the locking element', function() {
+            var event = new CustomEvent('touchstart', {
+              bubbles: true,
+              cancelable: true
+            });
+            grandChildOne.dispatchEvent(event);
+            expect(event.defaultPrevented).to.be.eql(false);
+          });
         });
       });
     });

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -35,8 +35,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
       var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
-      event.wheelDeltaX = deltaX;
-      event.wheelDeltaY = deltaY;
+      event.deltaX = deltaX;
+      event.deltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -68,42 +68,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(fireWheel(childTwo, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(fireWheel(grandChildTwo, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(fireWheel(ancestor, 0, -10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(fireWheel(childOne, 0, -10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(fireWheel(grandChildOne, 0, -10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
         });
 
         test('does not check locked elements when there are no locking elements', function() {
           sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
-          fireWheel(childOne, 0, -10);
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          fireWheel(childOne, 0, -10);
+          fireWheel(childOne, 0, 10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
         });
@@ -125,8 +125,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 bubbles: true,
                 cancelable: true
               });
-              event.wheelDeltaX = 0;
-              event.wheelDeltaY = -10;
+              event.deltaX = 0;
+              event.deltaY = 10;
               return event;
             });
           });

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -34,7 +34,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
+      event.wheelDeltaX = deltaX;
+      event.wheelDeltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -66,42 +68,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('recognizes sibling as locked', function() {
-          expect(fireWheel(childTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(childTwo, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes neice as locked', function() {
-          expect(fireWheel(grandChildTwo, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(grandChildTwo, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes parent as locked', function() {
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes ancestor as locked', function() {
-          expect(fireWheel(ancestor, 0, 10).defaultPrevented).to.be.equal(true);
+          expect(fireWheel(ancestor, 0, -10).defaultPrevented).to.be.equal(true);
         });
 
         test('recognizes locking child as unlocked', function() {
-          expect(fireWheel(childOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(childOne, 0, -10).defaultPrevented).to.be.equal(false);
         });
 
         test('recognizes descendant of locking child as unlocked', function() {
-          expect(fireWheel(grandChildOne, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(grandChildOne, 0, -10).defaultPrevented).to.be.equal(false);
         });
 
         test('unlocks locked elements when there are no locking elements', function() {
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
 
-          expect(fireWheel(parent, 0, 10).defaultPrevented).to.be.equal(false);
+          expect(fireWheel(parent, 0, -10).defaultPrevented).to.be.equal(false);
         });
 
         test('does not check locked elements when there are no locking elements', function() {
           sinon.spy(Polymer.IronDropdownScrollManager, 'shouldPreventScrolling');
-          fireWheel(childOne, 0, 10);
+          fireWheel(childOne, 0, -10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
           Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
-          fireWheel(childOne, 0, 10);
+          fireWheel(childOne, 0, -10);
           expect(Polymer.IronDropdownScrollManager
               .shouldPreventScrolling.callCount).to.be.eql(1);
         });
@@ -119,10 +121,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ];
 
             events = scrollEvents.map(function(scrollEvent) {
-              return new CustomEvent(scrollEvent, {
+              var event = new CustomEvent(scrollEvent, {
                 bubbles: true,
                 cancelable: true
               });
+              event.wheelDeltaX = 0;
+              event.wheelDeltaY = -10;
+              return event;
             });
           });
 

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -261,6 +261,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
+            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
+              .to.be.equal(true);
             expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
 
             if (openCount === 0) {
@@ -304,6 +306,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
           runAfterOpen(dropdown, function() {
+            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
+              .to.be.equal(false);
             expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
             done();
           });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -157,8 +157,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         cancelable: true,
         bubbles: true
       });
-      event.wheelDeltaX = deltaX;
-      event.wheelDeltaY = deltaY;
+      event.deltaX = deltaX;
+      event.deltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -261,7 +261,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
-            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(true);
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
 
             if (openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
@@ -304,7 +304,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
           runAfterOpen(dropdown, function() {
-            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(false);
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
             done();
           });
         });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -9,6 +9,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>iron-dropdown basic tests</title>
@@ -54,6 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     height: 3000px;
   }
 </style>
+
 <body>
 
   <test-fixture id="TrivialDropdown">
@@ -133,6 +135,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+
   <script>
     function elementIsVisible(element) {
       var contentRect = element.getBoundingClientRect();
@@ -150,11 +153,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
+      var event = new CustomEvent('wheel', {
+        cancelable: true,
+        bubbles: true
+      });
       event.wheelDeltaX = deltaX;
       event.wheelDeltaY = deltaY;
       node.dispatchEvent(event);
       return event;
+    }
+
+    function dispatchScroll(target, scrollLeft, scrollTop) {
+      target.scrollLeft = scrollLeft;
+      target.scrollTop = scrollTop;
+      target.dispatchEvent(new CustomEvent('scroll', { bubbles:true } ));
     }
 
     suite('<iron-dropdown>', function() {
@@ -172,14 +184,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('shows dropdown content when opened', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             expect(elementIsVisible(content)).to.be.equal(true);
             done();
           });
         });
 
         test('hides dropdown content when outside is clicked', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             expect(elementIsVisible(content)).to.be.equal(true);
             dropdown.addEventListener('iron-overlay-closed', function() {
               expect(elementIsVisible(content)).to.be.equal(false);
@@ -195,7 +207,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             content = Polymer.dom(dropdown).querySelector('.dropdown-content');
           });
           test('focuses the content when opened', function(done) {
-            runAfterOpen(dropdown, function () {
+            runAfterOpen(dropdown, function() {
               expect(document.activeElement).to.be.equal(content);
               done();
             });
@@ -205,7 +217,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var focusableChild = Polymer.dom(content).querySelector('div[tabindex]');
             dropdown.focusTarget = focusableChild;
 
-            runAfterOpen(dropdown, function () {
+            runAfterOpen(dropdown, function() {
               expect(document.activeElement).to.not.be.equal(content);
               expect(document.activeElement).to.be.equal(focusableChild);
               done();
@@ -216,8 +228,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('locking scroll', function() {
 
+        var bigDiv, scrollTarget;
+        suiteSetup(function() {
+          bigDiv = document.createElement('div');
+          bigDiv.classList.add('big');
+          document.body.appendChild(bigDiv);
+          // Need to discover if html or body is scrollable.
+          // Here we are sure the page is scrollable.
+          document.documentElement.scrollTop = 1;
+          if (document.documentElement.scrollTop === 1) {
+            document.documentElement.scrollTop = 0;
+            scrollTarget = document.documentElement;
+          } else {
+            scrollTarget = document.body;
+          }
+        });
+
+        suiteTeardown(function() {
+          document.body.removeChild(bigDiv);
+        });
+
         setup(function() {
           dropdown = fixture('TrivialDropdown');
+        });
+
+        teardown(function() {
+          dispatchScroll(scrollTarget, 0, 0);
         });
 
         test('should lock, only once', function(done) {
@@ -227,7 +263,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               .to.be.equal(1);
             expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(true);
 
-            if(openCount === 0) {
+            if (openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
               // that should not add the element to the `_lockingElements` stack twice
               dropdown.close();
@@ -238,6 +274,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             openCount++;
           });
         });
+
+        test('should lock scroll', function(done) {
+          runAfterOpen(dropdown, function() {
+            dispatchScroll(scrollTarget, 10, 10);
+            assert.equal(scrollTarget.scrollTop, 0, 'scrollTop ok');
+            assert.equal(scrollTarget.scrollLeft, 0, 'scrollLeft ok');
+            done();
+          });
+        });
+
+        test('can be disabled with `allowOutsideScroll`', function(done) {
+          dropdown.allowOutsideScroll = true;
+          runAfterOpen(dropdown, function() {
+            dispatchScroll(scrollTarget, 10, 10);
+            assert.equal(scrollTarget.scrollTop, 10, 'scrollTop ok');
+            assert.equal(scrollTarget.scrollLeft, 10, 'scrollLeft ok');
+            done();
+          });
+        });
+
       });
 
       suite('non locking scroll', function() {
@@ -247,7 +303,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(false);
             done();
           });
@@ -265,7 +321,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be re-aligned to the right and the top', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
@@ -278,7 +334,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be re-aligned to the bottom', function(done) {
           dropdown.verticalAlign = 'bottom';
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             parentRect = parent.getBoundingClientRect();
             dropdownRect = dropdown.getBoundingClientRect();
             assert.equal(dropdownRect.top, 0, 'top ok');
@@ -292,7 +348,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('handles parent\'s stacking context', function(done) {
           // This will create a new stacking context.
           parent.style.transform = 'translateZ(0)';
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
@@ -313,7 +369,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the bottom right', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
@@ -329,7 +385,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the top left', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
@@ -354,7 +410,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the top left', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = 10;
             dropdown.horizontalOffset = 10;
@@ -370,7 +426,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be offset towards the bottom right', function(done) {
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
             dropdown.verticalOffset = -10;
             dropdown.horizontalOffset = -10;
@@ -392,7 +448,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=left', function(done) {
           var parent = fixture('RTLDropdownLeft');
           dropdown = parent.querySelector('iron-dropdown');
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             // In RTL, if `horizontalAlign` is "left", that's the same as
             // being right-aligned in LTR. So the dropdown should be in the top
             // right corner.
@@ -406,7 +462,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('with horizontalAlign=right', function(done) {
           var parent = fixture('RTLDropdownRight');
           dropdown = parent.querySelector('iron-dropdown');
-          runAfterOpen(dropdown, function () {
+          runAfterOpen(dropdown, function() {
             // In RTL, if `horizontalAlign` is "right", that's the same as
             // being left-aligned in LTR. So the dropdown should be in the top
             // left corner.
@@ -420,4 +476,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </body>
+
 </html>

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -318,15 +318,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function() {
           parent = fixture('AlignedDropdown');
           dropdown = parent.querySelector('iron-dropdown');
+          parentRect = parent.getBoundingClientRect();
         });
 
         test('can be re-aligned to the right and the top', function(done) {
           runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
-            parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
-            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
+            assert.equal(dropdownRect.bottom, window.innerHeight, 'bottom ok');
             assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });
@@ -335,7 +335,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('can be re-aligned to the bottom', function(done) {
           dropdown.verticalAlign = 'bottom';
           runAfterOpen(dropdown, function() {
-            parentRect = parent.getBoundingClientRect();
             dropdownRect = dropdown.getBoundingClientRect();
             assert.equal(dropdownRect.top, 0, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
@@ -350,10 +349,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           parent.style.transform = 'translateZ(0)';
           runAfterOpen(dropdown, function() {
             dropdownRect = dropdown.getBoundingClientRect();
-            parentRect = parent.getBoundingClientRect();
             assert.equal(dropdownRect.top, parentRect.top, 'top ok');
             assert.equal(dropdownRect.left, 0, 'left ok');
-            assert.equal(dropdownRect.bottom, document.documentElement.clientHeight, 'bottom ok');
+            assert.equal(dropdownRect.bottom, window.innerHeight, 'bottom ok');
             assert.equal(dropdownRect.right, parentRect.right, 'right ok');
             done();
           });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -150,7 +150,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function fireWheel(node, deltaX, deltaY) {
       // IE 11 doesn't support WheelEvent, use CustomEvent.
-      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      var event = new CustomEvent('wheel', {cancelable: true, bubbles: true});
+      event.wheelDeltaX = deltaX;
+      event.wheelDeltaY = deltaY;
       node.dispatchEvent(event);
       return event;
     }
@@ -223,7 +225,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
-            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
+            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(true);
 
             if(openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
@@ -246,7 +248,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
           runAfterOpen(dropdown, function () {
-            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
+            expect(fireWheel(document.body, 0, -10).defaultPrevented).to.be.equal(false);
             done();
           });
         });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -148,6 +148,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       overlay.open();
     }
 
+    function fireWheel(node, deltaX, deltaY) {
+      // IE 11 doesn't support WheelEvent, use CustomEvent.
+      var event = new CustomEvent('wheel', {deltaX: deltaX, deltaY: deltaY, cancelable: true, bubbles: true});
+      node.dispatchEvent(event);
+      return event;
+    }
+
     suite('<iron-dropdown>', function() {
       var dropdown;
       var content;
@@ -216,8 +223,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(dropdown, function() {
             expect(Polymer.IronDropdownScrollManager._lockingElements.length)
               .to.be.equal(1);
-            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-              .to.be.equal(true);
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(true);
 
             if(openCount === 0) {
               // This triggers a second `pushScrollLock` with the same element, however
@@ -239,9 +245,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be disabled with `allowOutsideScroll`', function(done) {
-          runAfterOpen(dropdown, function() {
-            expect(Polymer.IronDropdownScrollManager.elementIsScrollLocked(document.body))
-              .to.be.equal(false);
+          runAfterOpen(dropdown, function () {
+            expect(fireWheel(document.body, 0, 10).defaultPrevented).to.be.equal(false);
             done();
           });
         });

--- a/test/x-scrollable-element.html
+++ b/test/x-scrollable-element.html
@@ -12,11 +12,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="x-scrollable-element">
   <template>
+    <style>
+      :host {
+        display: block;
+        height: 100px;
+        border: 1px solid red;
+        overflow: auto;
+      }
+      #ChildOne, #ChildTwo {
+        height: 200px;
+        border: 1px solid blue;
+        overflow: auto;
+      }
+      #GrandchildOne, #GrandchildTwo {
+        height: 300px;
+        border: 1px solid green;
+        overflow: auto;
+      }
+      .scrollContent {
+        height: 400px;
+        background-color: yellow;
+      }
+    </style>
     <div id="ChildOne">
-      <div id="GrandchildOne"></div>
+      <div id="GrandchildOne">
+        <div class="scrollContent"></div>
+      </div>
     </div>
     <div id="ChildTwo">
-      <div id="GrandchildTwo"></div>
+      <div id="GrandchildTwo">
+        <div class="scrollContent"></div>
+      </div>
     </div>
   </template>
   <script>


### PR DESCRIPTION
(started in https://github.com/PolymerElements/iron-dropdown/pull/64, which was reverted because it introduced a breaking change)

Fixes #54 , fixes #43.

For #54, the goal is to keep the overflow on `document.body`, and prevent the scrolling from happening if:
- the scroll happens outside the locked element
- the scroll happens inside the locked element, but the target is contained in scrollable parents that cannot scroll (because they're at their boundaries already)

For #43, the `scroll` event listener on document will restore scrolling if it happens because of a user text selection or if the user scrolls through the side scroll bars. If `allowScrollOutside`, it will call `refit`.

I've profiled the performance of the change using this file https://gist.github.com/valdrinkoshi/5fb1c67fddd31782508b9e39c8ac25a3, and I'm seeing that overall fps is around 60fps, except some longer frames which go down to 25-30fps, and I believe it is mainly because of the `touchmove` listener which interrupts the scrolling to execute the javascript (in the timeline I see only the Painting and Rendering activities during this longer frames).

Interactions:
![heavy-test-mobile](https://cloud.githubusercontent.com/assets/6173664/16824381/c1669794-496b-11e6-8b19-7588d699a197.gif)

Longer frame example:
![heavy-test-longer-frame](https://cloud.githubusercontent.com/assets/6173664/16824413/0133f344-496c-11e6-85fb-ab75b5adf978.gif)

