### PR TITLE
remove keydown listener

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,7 @@
     "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
     "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.0.0",
     "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0",
-    "neon-animation": "polymerelements/neon-animation#^1.0.0",
-    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.0.0"
+    "neon-animation": "polymerelements/neon-animation#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 
 <script>
   (function() {
@@ -133,11 +132,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _unlockedElementCache: null,
 
-      _isScrollingKeypress: function(event) {
-        return Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(
-          event, 'pageup pagedown home end up left down right');
-      },
-
       _hasCachedLockedElement: function(element) {
         return this._lockedElementCache.indexOf(element) > -1;
       },
@@ -206,8 +200,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.addEventListener('touchstart', this._boundScrollHandler, true);
         // Mobile devices can scroll on touch move:
         document.addEventListener('touchmove', this._boundScrollHandler, true);
-        // Capture keydown to prevent scrolling keys (pageup, pagedown etc.)
-        document.addEventListener('keydown', this._boundScrollHandler, true);
       },
 
       _unlockScrollInteractions: function() {
@@ -216,7 +208,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.removeEventListener('DOMMouseScroll', this._boundScrollHandler, true);
         document.removeEventListener('touchstart', this._boundScrollHandler, true);
         document.removeEventListener('touchmove', this._boundScrollHandler, true);
-        document.removeEventListener('keydown', this._boundScrollHandler, true);
       },
 
       /**
@@ -228,11 +219,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @private
        */
       _shouldPreventScrolling: function(event) {
-        // Avoid expensive checks if the event is not one of the observed keys.
-        if (event.type === 'keydown') {
-          // Prevent event if it is one of the scrolling keys.
-          return this._isScrollingKeypress(event);
-        }
 
         // Update if root target changed. For touch events, ensure we don't
         // update during touchmove.

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -159,6 +159,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             grandChildOne.dispatchEvent(event);
             expect(event.defaultPrevented).to.be.eql(false);
           });
+
+          test('arrow keyboard events not prevented by manager', function() {
+            // Even if these events might cause scrolling, they should not be
+            // prevented because they might cause a11y issues (e.g. arrow keys
+            // used for navigating the content). iron-dropdown is capable of
+            // restoring the scroll position of the document if necessary.
+            var left = MockInteractions.keyboardEventFor('keydown', 37);
+            var up = MockInteractions.keyboardEventFor('keydown', 38);
+            var right = MockInteractions.keyboardEventFor('keydown', 39);
+            var down = MockInteractions.keyboardEventFor('keydown', 40);
+            grandChildOne.dispatchEvent(left);
+            grandChildOne.dispatchEvent(up);
+            grandChildOne.dispatchEvent(right);
+            grandChildOne.dispatchEvent(down);
+            expect(left.defaultPrevented).to.be.eql(false);
+            expect(up.defaultPrevented).to.be.eql(false);
+            expect(right.defaultPrevented).to.be.eql(false);
+            expect(down.defaultPrevented).to.be.eql(false);
+          });
         });
       });
     });


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dropdown-menu/issues/187, fixes https://github.com/PolymerElements/iron-dropdown/issues/96
Calling `event.preventDefault()` on `keydown` events can break a11y. 
`iron-dropdown-scroll-manager` needed to prevent in order to avoid any scroll from happening, but since `iron-dropdown` is capable of [restoring the scroll position](https://github.com/PolymerElements/iron-dropdown/blob/master/iron-dropdown.html#L260), the `keydown` event listener is not really needed. We gain a11y in exchange of a reflow...

 