### PR TITLE
Disable pointer-events when dropdown is animating

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -56,6 +56,7 @@ method is called on the element.
 
       #contentWrapper.animating ::content > * {
         overflow: hidden;
+        pointer-events: none;
       }
     </style>
 


### PR DESCRIPTION
This prevents accidentally clicking dropdown contents while the dropdown is animating in or out.

Fixes #97.
