### PR TITLE
remove listener on detached

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "polymer": "polymer/polymer#^1.1.0",
     "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
-    "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.0.0",
+    "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.8.6",
     "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0",
     "neon-animation": "polymerelements/neon-animation#^1.0.0"
   },

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -191,6 +191,7 @@ method is called on the element.
 
         detached: function() {
           this.cancelAnimation();
+          document.removeEventListener('scroll', this._boundOnCaptureScroll);
           Polymer.IronDropdownScrollManager.removeScrollLock(this);
         },
 


### PR DESCRIPTION
Fixes tests. This should have been done in PR https://github.com/PolymerElements/iron-dropdown/pull/93. Tests were passing because of an earlier version of `iron-overlay-behavior` which was setting `opened = false` on detached. This has been fixed in v1.8.6 https://github.com/PolymerElements/iron-overlay-behavior/pull/183.
Ah, dependencies..
