### PR TITLE
_composedTreeContains - non-element distributed nodes

### DIFF
--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -152,6 +152,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var contentIndex;
         var nodeIndex;
 
+        if (element.nodeType !== 1) {
+          // element is not an HTMLElement and so it has no children.
+          return element === child;
+        }
+        
         if (element.contains(child)) {
           return true;
         }


### PR DESCRIPTION
This method should handle non-element distributed nodes (e.g., text).
