### PR TITLE
2.0 preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 sudo: required
 before_script:
-  - npm install -g bower polymer-cli@next
+  - npm install -g polymer-cli
   - polymer install --variants
-  - sudo mv /usr/bin/google-chrome /usr/bin/google-chrome-old
-  - sudo mv /usr/bin/google-chrome-beta /usr/bin/google-chrome
 env:
   global:
     - secure: >-
@@ -18,7 +16,7 @@ addons:
     sources:
       - google-chrome
     packages:
-      - google-chrome-beta
+      - google-chrome-stable
 script:
   - xvfb-run polymer test
   - >-

--- a/README.md
+++ b/README.md
@@ -1,23 +1,9 @@
-
-<!---
-
-This README is automatically generated from the comments in these files:
-iron-dropdown.html
-
-Edit those files, and our readme bot will duplicate them over here!
-Edit this file, and the bot will squash your changes :)
-
-The bot does some handling of markdown. Please file a bug if it does the wrong
-thing! https://github.com/PolymerLabs/tedium/issues
-
--->
-
 [![Build status](https://travis-ci.org/PolymerElements/iron-dropdown.svg?branch=master)](https://travis-ci.org/PolymerElements/iron-dropdown)
 
 _[Demo and API docs](https://elements.polymer-project.org/elements/iron-dropdown)_
 
 
-##&lt;iron-dropdown&gt;
+## &lt;iron-dropdown&gt;
 
 `<iron-dropdown>` is a generalized element that is useful when you have
 hidden content (`dropdown-content`) that is revealed due to some change in
@@ -43,4 +29,6 @@ In the above example, the `<div>` assigned to the `dropdown-content` slot will b
 hidden until the dropdown element has `opened` set to true, or when the `open`
 method is called on the element.
 
-
+### Changes in 2.0
+- Removed the private property `_focusTarget` which was deprecated.
+- `neon-animation 2.0` doesn't import the Web Animations polyfill, so you'll have to import it ([see example](demo/index.html))

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ configured.
 </iron-dropdown>
 ```
 
-In the above example, the `<div>` with slot `dropdown-content` will be
+In the above example, the `<div>` assigned to the `dropdown-content` slot will be
 hidden until the dropdown element has `opened` set to true, or when the `open`
 method is called on the element.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _[Demo and API docs](https://elements.polymer-project.org/elements/iron-dropdown
 ##&lt;iron-dropdown&gt;
 
 `<iron-dropdown>` is a generalized element that is useful when you have
-hidden content (`.dropdown-content`) that is revealed due to some change in
+hidden content (`dropdown-content`) that is revealed due to some change in
 state that should cause it to do so.
 
 Note that this is a low-level element intended to be used as part of other
@@ -30,16 +30,16 @@ Examples of elements that might be implemented using an `iron-dropdown`
 include comboboxes, menubuttons, selects. The list goes on.
 
 The `<iron-dropdown>` element exposes attributes that allow the position
-of the `.dropdown-content` relative to the `.dropdown-trigger` to be
+of the `dropdown-content` relative to the `dropdown-trigger` to be
 configured.
 
 ```html
 <iron-dropdown horizontal-align="right" vertical-align="top">
-  <div class="dropdown-content">Hello!</div>
+  <div slot="dropdown-content">Hello!</div>
 </iron-dropdown>
 ```
 
-In the above example, the `<div>` with class `.dropdown-content` will be
+In the above example, the `<div>` with slot `dropdown-content` will be
 hidden until the dropdown element has `opened` set to true, or when the `open`
 method is called on the element.
 

--- a/bower.json
+++ b/bower.json
@@ -20,16 +20,16 @@
   "homepage": "https://github.com/PolymerElements/iron-dropdown",
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0-rc.1",
-    "iron-behaviors": "polymerelements/iron-behaviors#2.0-preview",
+    "iron-behaviors": "PolymerElements/iron-behaviors#2.0-preview",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#2.0-preview",
     "neon-animation": "PolymerElements/neon-animation#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "polymerelements/iron-component-page#2.0-preview",
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
     "web-animations-js": "web-animations/web-animations-js#^2.2.0",
-    "iron-image": "polymerelements/iron-image#2.0-preview",
+    "iron-image": "PolymerElements/iron-image#2.0-preview",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
@@ -37,16 +37,16 @@
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.7.0",
-        "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
+        "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
         "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.8.6",
         "neon-animation": "PolymerElements/neon-animation#^1.0.0"
       },
       "devDependencies": {
-        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
         "web-animations-js": "web-animations/web-animations-js#^2.2.0",
-        "iron-image": "polymerelements/iron-image#^1.0.0",
+        "iron-image": "PolymerElements/iron-image#^1.0.0",
         "web-component-tester": "^4.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-dropdown",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "An unstyled element that works similarly to a native browser select",
   "authors": [
     "The Polymer Authors"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-dropdown",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "An unstyled element that works similarly to a native browser select",
   "authors": [
     "The Polymer Authors"

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/PolymerElements/iron-dropdown",
   "dependencies": {
     "polymer": "Polymer/polymer#2.0-preview",
-    "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
+    "iron-behaviors": "polymerelements/iron-behaviors#2.0-preview",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#2.0-preview",
     "neon-animation": "PolymerElements/neon-animation#2.0-preview"
   },
@@ -40,6 +40,9 @@
     "polymer": "2.0-preview",
     "webcomponentsjs": "v1",
     "iron-a11y-keys-behavior": "2.0-preview",
-    "iron-resizable-behavior": "2.0-preview"
+    "iron-resizable-behavior": "2.0-preview",
+    "iron-behaviors": "2.0-preview",
+    "iron-selector": "2.0-preview",
+    "iron-meta": "2.0-preview"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "polymer": "https://github.com/PolymerLabs/alacarte.git#master",
     "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
-    "iron-overlay-behavior": "https://github.com/notwaldorf/iron-overlay.git#2.0-preview",
+    "iron-overlay-behavior": "https://github.com/notwaldorf/iron-overlay-behavior.git#2.0-preview",
     "neon-animation": "https://github.com/notwaldorf/neon-animation.git#2.0-preview"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -19,26 +19,26 @@
   "license": "http://polymer.github.io/LICENSE.txt",
   "homepage": "https://github.com/PolymerElements/iron-dropdown",
   "dependencies": {
-    "polymer": "https://github.com/PolymerLabs/alacarte.git#master",
+    "polymer": "Polymer/polymer#2.0-preview",
     "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
-    "iron-overlay-behavior": "https://github.com/notwaldorf/iron-overlay-behavior.git#2.0-preview",
-    "neon-animation": "https://github.com/notwaldorf/neon-animation.git#2.0-preview"
+    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#2.0-preview",
+    "neon-animation": "PolymerElements/neon-animation#2.0-preview"
   },
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-    "iron-demo-helpers": "https://github.com/notwaldorf/iron-demo-helpers.git#2.0-preview",
-    "iron-test-helpers": "https://github.com/notwaldorf/iron-test-helpers.git#2.0-preview",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1",
     "iron-image": "polymerelements/iron-image#^1.0.0"
   },
   "ignore": [],
   "resolutions": {
     "iron-flex-layout": "2.0-preview",
     "test-fixture": "custom-elements-v1",
-    "polymer": "master",
-    "webcomponentsjs": "v1-polymer-edits",
+    "polymer": "2.0-preview",
+    "webcomponentsjs": "v1",
     "iron-a11y-keys-behavior": "2.0-preview",
     "iron-resizable-behavior": "2.0-preview"
   }

--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1",
+    "web-animations-js": "web-animations/web-animations-js#^2.2.0",
     "iron-image": "polymerelements/iron-image#^1.0.0"
   },
   "ignore": [],

--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,26 @@
     "web-animations-js": "web-animations/web-animations-js#^2.2.0",
     "iron-image": "polymerelements/iron-image#^1.0.0"
   },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.7.0",
+        "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
+        "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.8.6",
+        "neon-animation": "PolymerElements/neon-animation#^1.0.0"
+      },
+      "devDependencies": {
+        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+        "web-component-tester": "^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+        "web-animations-js": "web-animations/web-animations-js#^2.2.0",
+        "iron-image": "polymerelements/iron-image#^1.0.0"
+      }
+    }
+  },
   "ignore": [],
   "resolutions": {
     "iron-flex-layout": "2.0-preview",

--- a/bower.json
+++ b/bower.json
@@ -28,11 +28,11 @@
     "iron-component-page": "polymerelements/iron-component-page#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
-    "web-component-tester": "^6.0.0-prerelease.6",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1",
     "web-animations-js": "web-animations/web-animations-js#^2.2.0",
-    "iron-image": "polymerelements/iron-image#2.0-preview"
+    "iron-image": "polymerelements/iron-image#2.0-preview",
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
   "variants": {
     "1.x": {
@@ -46,11 +46,11 @@
         "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+        "web-animations-js": "web-animations/web-animations-js#^2.2.0",
+        "iron-image": "polymerelements/iron-image#^1.0.0",
         "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "web-component-tester": "^4.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-        "web-animations-js": "web-animations/web-animations-js#^2.2.0",
-        "iron-image": "polymerelements/iron-image#^1.0.0"
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       }
     }
   },

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
         "polymer": "Polymer/polymer#^1.7.0",
         "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
         "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.8.6",
-        "neon-animation": "PolymerElements/neon-animation#2.0-preview"
+        "neon-animation": "PolymerElements/neon-animation#^1.0.0"
       },
       "devDependencies": {
         "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
@@ -51,21 +51,11 @@
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
         "web-animations-js": "web-animations/web-animations-js#^2.2.0",
         "iron-image": "polymerelements/iron-image#^1.0.0"
-      },
-      "resolutions": {
-        "iron-resizable-behavior": "^1.0.0",
-        "iron-selector": "^1.0.0",
-        "iron-meta": "^1.0.0",
-        "polymer": "^1.7.0",
-        "test-fixture": "^1.0.0",
-        "webcomponentsjs": "^0.7.0"
       }
     }
   },
   "ignore": [],
   "resolutions": {
-    "polymer": "2.0-preview",
-    "test-fixture": "custom-elements-v1",
-    "webcomponentsjs": "v1"
+    "test-fixture": "custom-elements-v1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -28,9 +28,9 @@
     "iron-component-page": "polymerelements/iron-component-page#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^2.0.0",
-    "web-component-tester": "v6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1",
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "web-component-tester": "^6.0.0-prerelease.6",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1",
     "web-animations-js": "web-animations/web-animations-js#^2.2.0",
     "iron-image": "polymerelements/iron-image#2.0-preview"
   },
@@ -54,8 +54,5 @@
       }
     }
   },
-  "ignore": [],
-  "resolutions": {
-    "test-fixture": "^2.0.0"
-  }
+  "ignore": []
 }

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "license": "http://polymer.github.io/LICENSE.txt",
   "homepage": "https://github.com/PolymerElements/iron-dropdown",
   "dependencies": {
-    "polymer": "Polymer/polymer#2.0-preview",
+    "polymer": "Polymer/polymer#^2.0.0-rc.1",
     "iron-behaviors": "polymerelements/iron-behaviors#2.0-preview",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#2.0-preview",
     "neon-animation": "PolymerElements/neon-animation#2.0-preview"

--- a/bower.json
+++ b/bower.json
@@ -25,14 +25,14 @@
     "neon-animation": "PolymerElements/neon-animation#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+    "iron-component-page": "polymerelements/iron-component-page#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1",
     "web-animations-js": "web-animations/web-animations-js#^2.2.0",
-    "iron-image": "polymerelements/iron-image#^1.0.0"
+    "iron-image": "polymerelements/iron-image#2.0-preview"
   },
   "variants": {
     "1.x": {
@@ -51,19 +51,21 @@
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
         "web-animations-js": "web-animations/web-animations-js#^2.2.0",
         "iron-image": "polymerelements/iron-image#^1.0.0"
+      },
+      "resolutions": {
+        "iron-resizable-behavior": "^1.0.0",
+        "iron-selector": "^1.0.0",
+        "iron-meta": "^1.0.0",
+        "polymer": "^1.7.0",
+        "test-fixture": "^1.0.0",
+        "webcomponentsjs": "^0.7.0"
       }
     }
   },
   "ignore": [],
   "resolutions": {
-    "iron-flex-layout": "2.0-preview",
-    "test-fixture": "custom-elements-v1",
     "polymer": "2.0-preview",
-    "webcomponentsjs": "v1",
-    "iron-a11y-keys-behavior": "2.0-preview",
-    "iron-resizable-behavior": "2.0-preview",
-    "iron-behaviors": "2.0-preview",
-    "iron-selector": "2.0-preview",
-    "iron-meta": "2.0-preview"
+    "test-fixture": "custom-elements-v1",
+    "webcomponentsjs": "v1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-dropdown",
-  "version": "1.5.5",
+  "version": "2.0.0",
   "description": "An unstyled element that works similarly to a native browser select",
   "authors": [
     "The Polymer Authors"
@@ -19,20 +19,27 @@
   "license": "http://polymer.github.io/LICENSE.txt",
   "homepage": "https://github.com/PolymerElements/iron-dropdown",
   "dependencies": {
-    "polymer": "polymer/polymer#^1.1.0",
+    "polymer": "https://github.com/PolymerLabs/alacarte.git#master",
     "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
-    "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.8.6",
-    "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0",
-    "neon-animation": "polymerelements/neon-animation#^1.0.0"
+    "iron-overlay-behavior": "https://github.com/notwaldorf/iron-overlay.git#2.0-preview",
+    "neon-animation": "https://github.com/notwaldorf/neon-animation.git#2.0-preview"
   },
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-    "test-fixture": "polymerelements/test-fixture#^1.0.0",
-    "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
-    "paper-styles": "polymerelements/paper-styles#^1.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "iron-demo-helpers": "https://github.com/notwaldorf/iron-demo-helpers.git#2.0-preview",
+    "iron-test-helpers": "https://github.com/notwaldorf/iron-test-helpers.git#2.0-preview",
+    "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits",
     "iron-image": "polymerelements/iron-image#^1.0.0"
   },
-  "ignore": []
+  "ignore": [],
+  "resolutions": {
+    "iron-flex-layout": "2.0-preview",
+    "test-fixture": "custom-elements-v1",
+    "polymer": "master",
+    "webcomponentsjs": "v1-polymer-edits",
+    "iron-a11y-keys-behavior": "2.0-preview",
+    "iron-resizable-behavior": "2.0-preview"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
         "polymer": "Polymer/polymer#^1.7.0",
         "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0",
         "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.8.6",
-        "neon-animation": "PolymerElements/neon-animation#^1.0.0"
+        "neon-animation": "PolymerElements/neon-animation#2.0-preview"
       },
       "devDependencies": {
         "iron-component-page": "polymerelements/iron-component-page#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
     "web-animations-js": "web-animations/web-animations-js#^2.2.0",
     "iron-image": "polymerelements/iron-image#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
@@ -48,7 +47,6 @@
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
         "web-animations-js": "web-animations/web-animations-js#^2.2.0",
         "iron-image": "polymerelements/iron-image#^1.0.0",
-        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "web-component-tester": "^4.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       }

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="x-select.html">
 
-  <style is="custom-style" include="demo-pages-shared-styles">
+  <custom-style><style is="custom-style" include="demo-pages-shared-styles">
     demo-snippet {
       --demo-snippet-code: {
         max-height: 250px;
@@ -81,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       box-shadow: 0px 2px 6px #ccc;
       border-radius: 3px;
     }
-  </style>
+  </style></custom-style>
 </head>
 
 <body unresolved class="centered">

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,6 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <title>iron-dropdown</title>
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-animations-js/web-animations-next-lite.min.js"></script>
+
   <link rel="import" href="../../iron-image/iron-image.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,15 +9,24 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
+
 <head>
 
   <title>iron-dropdown</title>
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../iron-image/iron-image.html">
-  <link rel="import" href="../../paper-styles/demo-pages.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+
   <link rel="import" href="x-select.html">
-  <style>
+
+  <style is="custom-style" include="demo-pages-shared-styles">
+    demo-snippet {
+      --demo-snippet-code: {
+        max-height: 250px;
+      }
+    }
 
     .dropdown-content {
       background-color: white;
@@ -44,12 +53,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       border-color: blue;
     }
 
-    ul {
-      margin: 0;
-      padding: 0;
-    }
-
-    li {
+    ul, li {
       display: block;
       position: relative;
       margin: 0;
@@ -79,82 +83,105 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </style>
 </head>
-<body>
-  <template is="dom-bind" id="Demo">
-   <div class="vertical-section vertical-section-container ">
-      <h1>iron-dropdown</h1>
-      <p>Examples of vanilla elements.</p>
-      <div>
-        <x-select>
-          <button class="dropdown-trigger">Basic</button>
-          <div class="dropdown-content random-content">
-           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-          </div>
-        </x-select>
-        <x-select>
-          <button class="dropdown-trigger">Overflowing</button>
-          <div class="dropdown-content random-content">
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>
-          </div>
-        </x-select>
-        <x-select vertical-align="bottom">
-          <button class="dropdown-trigger">Bottom-left Aligned</button>
-          <div class="dropdown-content random-content">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-          </div>
-        </x-select>
-        <x-select horizontal-align="right" vertical-align="top">
-          <button class="dropdown-trigger">Top-right Aligned</button>
-          <div class="dropdown-content random-content">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-          </div>
-        </x-select>
-        <x-select horizontal-align="left" vertical-align="top">
-          <button class="dropdown-trigger"> Content</button>
-          <iron-image class="dropdown-content" src="../../iron-image/demo/polymer.svg"></iron-image>
-        </x-select>
-        <x-select horizontal-align="right" vertical-align="top">
-          <button class="dropdown-trigger">Unordered list</button>
-          <ul class="dropdown-content" tabindex="0">
-            <template is="dom-repeat" items="[[dinosaurs]]">
+
+<body unresolved class="centered">
+  <h3>Basic</h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <x-select>
+        <button slot="dropdown-trigger">Basic</button>
+        <div class="dropdown-content random-content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </div>
+      </x-select>
+      <x-select>
+        <button slot="dropdown-trigger">Overflowing</button>
+        <div class="dropdown-content random-content">
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+            irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem
+            quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam
+            eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure
+            reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>
+        </div>
+      </x-select>
+    </template>
+  </demo-snippet>
+
+  <h3>Alignment</h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <x-select vertical-align="bottom">
+        <button slot="dropdown-trigger">Bottom-left Aligned</button>
+        <div class="dropdown-content random-content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </div>
+      </x-select>
+      <x-select horizontal-align="right" vertical-align="top">
+        <button slot="dropdown-trigger">Top-right Aligned</button>
+        <div class="dropdown-content random-content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </div>
+      </x-select>
+    </template>
+  </demo-snippet>
+
+  <h3>Content</h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <x-select horizontal-align="left" vertical-align="top">
+        <button slot="dropdown-trigger">Content</button>
+        <iron-image class="dropdown-content" src="../../iron-image/demo/polymer.svg"></iron-image>
+      </x-select>
+      <x-select horizontal-align="right" vertical-align="top">
+        <button slot="dropdown-trigger">Unordered list</button>
+        <ul class="dropdown-content" tabindex="0">
+          <dom-repeat id="Demo">
+            <template>
               <li><a href="javascript:void(0)">[[item]]</a></li>
             </template>
-          </ul>
-        </x-select>
-      </div>
-    </div>
-  </template>
+          </dom-repeat>
+        </ul>
+      </x-select>
 
-  <script>
-    Demo.dinosaurs = [
-      'allosaurus',
-      'brontosaurus',
-      'carcharodontosaurus',
-      'diplodocus',
-      'ekrixinatosaurus',
-      'fukuiraptor',
-      'gallimimus',
-      'hadrosaurus',
-      'iguanodon',
-      'jainosaurus',
-      'kritosaurus',
-      'liaoceratops',
-      'megalosaurus',
-      'nemegtosaurus',
-      'ornithomimus',
-      'protoceratops',
-      'quetecsaurus',
-      'rajasaurus',
-      'stegosaurus',
-      'triceratops',
-      'utahraptor',
-      'vulcanodon',
-      'wannanosaurus',
-      'xenoceratops',
-      'yandusaurus',
-      'zephyrosaurus'
-    ];
-  </script>
+      <script>
+        Demo.items = [
+          'allosaurus',
+          'brontosaurus',
+          'carcharodontosaurus',
+          'diplodocus',
+          'ekrixinatosaurus',
+          'fukuiraptor',
+          'gallimimus',
+          'hadrosaurus',
+          'iguanodon',
+          'jainosaurus',
+          'kritosaurus',
+          'liaoceratops',
+          'megalosaurus',
+          'nemegtosaurus',
+          'ornithomimus',
+          'protoceratops',
+          'quetecsaurus',
+          'rajasaurus',
+          'stegosaurus',
+          'triceratops',
+          'utahraptor',
+          'vulcanodon',
+          'wannanosaurus',
+          'xenoceratops',
+          'yandusaurus',
+          'zephyrosaurus'
+        ];
+      </script>
+    </template>
+  </demo-snippet>
+
+
+
 </body>
+
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -92,14 +92,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <x-select>
         <button slot="dropdown-trigger">Basic</button>
-        <div class="dropdown-content random-content">
+        <div slot="dropdown-content" class="dropdown-content random-content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
       </x-select>
       <x-select>
         <button slot="dropdown-trigger">Overflowing</button>
-        <div class="dropdown-content random-content">
+        <div slot="dropdown-content" class="dropdown-content random-content">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
             irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem
@@ -116,14 +116,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <x-select vertical-align="bottom">
         <button slot="dropdown-trigger">Bottom-left Aligned</button>
-        <div class="dropdown-content random-content">
+        <div slot="dropdown-content" class="dropdown-content random-content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
       </x-select>
       <x-select horizontal-align="right" vertical-align="top">
         <button slot="dropdown-trigger">Top-right Aligned</button>
-        <div class="dropdown-content random-content">
+        <div slot="dropdown-content" class="dropdown-content random-content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
@@ -136,13 +136,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <x-select horizontal-align="left" vertical-align="top">
         <button slot="dropdown-trigger">Content</button>
-        <iron-image class="dropdown-content" src="../../iron-image/demo/polymer.svg"></iron-image>
+        <iron-image slot="dropdown-content" class="dropdown-content" src="../../iron-image/demo/polymer.svg"></iron-image>
       </x-select>
       <x-select horizontal-align="right" vertical-align="top">
         <button slot="dropdown-trigger">Unordered list</button>
-        <ul class="dropdown-content" tabindex="0">
+        <ul slot="dropdown-content" class="dropdown-content" tabindex="0">
           <dom-repeat id="Demo">
-            <template>
+            <template is="dom-repeat">
               <li><a href="javascript:void(0)">[[item]]</a></li>
             </template>
           </dom-repeat>
@@ -178,6 +178,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           'yandusaurus',
           'zephyrosaurus'
         ];
+        // Support hybrid mode.
+        Demo.firstElementChild.items = Demo.items;
       </script>
     </template>
   </demo-snippet>

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,13 +15,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <title>iron-dropdown</title>
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../web-animations-js/web-animations-next-lite.min.js"></script>
 
   <link rel="import" href="../../iron-image/iron-image.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 
   <link rel="import" href="x-select.html">
+  <link rel="import" href="web-animations.html">
 
   <custom-style><style is="custom-style" include="demo-pages-shared-styles">
     demo-snippet {

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
 
-    .dropdown-content {
+    [slot="dropdown-content"] {
       background-color: white;
       line-height: 20px;
       border-radius: 3px;
@@ -92,14 +92,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <x-select>
         <button slot="dropdown-trigger">Basic</button>
-        <div slot="dropdown-content" class="dropdown-content random-content">
+        <div slot="dropdown-content" class="random-content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
       </x-select>
       <x-select>
         <button slot="dropdown-trigger">Overflowing</button>
-        <div slot="dropdown-content" class="dropdown-content random-content">
+        <div slot="dropdown-content" class="random-content">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
             irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem
@@ -116,14 +116,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <x-select vertical-align="bottom">
         <button slot="dropdown-trigger">Bottom-left Aligned</button>
-        <div slot="dropdown-content" class="dropdown-content random-content">
+        <div slot="dropdown-content" class="random-content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
       </x-select>
       <x-select horizontal-align="right" vertical-align="top">
         <button slot="dropdown-trigger">Top-right Aligned</button>
-        <div slot="dropdown-content" class="dropdown-content random-content">
+        <div slot="dropdown-content" class="random-content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
@@ -136,11 +136,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <x-select horizontal-align="left" vertical-align="top">
         <button slot="dropdown-trigger">Content</button>
-        <iron-image slot="dropdown-content" class="dropdown-content" src="../../iron-image/demo/polymer.svg"></iron-image>
+        <iron-image slot="dropdown-content" src="../../iron-image/demo/polymer.svg"></iron-image>
       </x-select>
       <x-select horizontal-align="right" vertical-align="top">
         <button slot="dropdown-trigger">Unordered list</button>
-        <ul slot="dropdown-content" class="dropdown-content" tabindex="0">
+        <ul slot="dropdown-content" tabindex="0">
           <dom-repeat id="Demo">
             <template is="dom-repeat">
               <li><a href="javascript:void(0)">[[item]]</a></li>

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,9 +19,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-image/iron-image.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+  <link rel="import" href="../../neon-animation/web-animations.html">
 
   <link rel="import" href="x-select.html">
-  <link rel="import" href="web-animations.html">
 
   <custom-style><style is="custom-style" include="demo-pages-shared-styles">
     demo-snippet {

--- a/demo/web-animations.html
+++ b/demo/web-animations.html
@@ -1,1 +1,0 @@
-<script src="../../web-animations-js/web-animations-next-lite.min.js"></script>

--- a/demo/web-animations.html
+++ b/demo/web-animations.html
@@ -1,0 +1,1 @@
+<script src="../../web-animations-js/web-animations-next-lite.min.js"></script>

--- a/demo/x-select.html
+++ b/demo/x-select.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       disabled="[[disabled]]"
       open-animation-config="[[openAnimationConfig]]"
       close-animation-config="[[closeAnimationConfig]]">
-      <slot></slot>
+      <slot name="dropdown-content" slot="dropdown-content"></slot>
     </iron-dropdown>
   </template>
   <script>

--- a/demo/x-select.html
+++ b/demo/x-select.html
@@ -21,7 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
     <div on-tap="open">
-      <content select=".dropdown-trigger"></content>
+      <content select="[slot='dropdown-trigger']"></content>
+      <slot name="dropdown-trigger"></slot>
     </div>
     <iron-dropdown id="dropdown"
       vertical-align="[[verticalAlign]]"
@@ -29,7 +30,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       disabled="[[disabled]]"
       open-animation-config="[[openAnimationConfig]]"
       close-animation-config="[[closeAnimationConfig]]">
-      <content select=".dropdown-content"></content>
+      <content></content>
+      <slot></slot>
     </iron-dropdown>
   </template>
   <script>

--- a/demo/x-select.html
+++ b/demo/x-select.html
@@ -21,7 +21,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
     <div on-tap="open">
-      <content select="[slot='dropdown-trigger']"></content>
       <slot name="dropdown-trigger"></slot>
     </div>
     <iron-dropdown id="dropdown"
@@ -30,7 +29,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       disabled="[[disabled]]"
       open-animation-config="[[openAnimationConfig]]"
       close-animation-config="[[closeAnimationConfig]]">
-      <content></content>
       <slot></slot>
     </iron-dropdown>
   </template>

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -177,13 +177,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return true;
         }
 
-        contentElements = Polymer.dom(element).querySelectorAll('content');
+        contentElements = Polymer.dom(element).querySelectorAll('content,slot');
 
         for (contentIndex = 0; contentIndex < contentElements.length; ++contentIndex) {
 
           distributedNodes = Polymer.dom(contentElements[contentIndex]).getDistributedNodes();
 
           for (nodeIndex = 0; nodeIndex < distributedNodes.length; ++nodeIndex) {
+            // Polymer 2.x returns slot.assignedNodes which can contain text nodes.
+            if (distributedNodes[nodeIndex].nodeType !== Node.ELEMENT_NODE) continue;
 
             if (this._composedTreeContains(distributedNodes[nodeIndex], child)) {
               return true;

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -13,8 +13,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   (function() {
     'use strict';
-    // Used to calculate the scroll direction during touch events.
-    var LAST_TOUCH_POSITION = {
+    /**
+     * Used to calculate the scroll direction during touch events.
+     * @type {!Object}
+     */
+    var lastTouchPosition = {
       pageX: 0,
       pageY: 0
     };
@@ -22,8 +25,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Used to avoid computing event.path and filter scrollable nodes (better perf).
      * @type {?EventTarget}
      */
-    var ROOT_TARGET = null;
-    var SCROLLABLE_NODES = [];
+    var lastRootTarget = null;
+    /**
+     * @type {!Array<Node>}
+     */
+    var lastScrollableNodes = [];
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
@@ -185,8 +191,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // If event has targetTouches (touch event), update last touch position.
         if (event.targetTouches) {
           var touch = event.targetTouches[0];
-          LAST_TOUCH_POSITION.pageX = touch.pageX;
-          LAST_TOUCH_POSITION.pageY = touch.pageY;
+          lastTouchPosition.pageX = touch.pageX;
+          lastTouchPosition.pageY = touch.pageY;
         }
       },
 
@@ -199,7 +205,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.addEventListener('mousewheel', this._boundScrollHandler, true);
         // IE:
         document.addEventListener('DOMMouseScroll', this._boundScrollHandler, true);
-        // Save the SCROLLABLE_NODES on touchstart, to be used on touchmove.
+        // Save the lastScrollableNodes on touchstart, to be used on touchmove.
         document.addEventListener('touchstart', this._boundScrollHandler, true);
         // Mobile devices can scroll on touch move:
         document.addEventListener('touchmove', this._boundScrollHandler, true);
@@ -226,13 +232,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Update if root target changed. For touch events, ensure we don't
         // update during touchmove.
         var target = Polymer.dom(event).rootTarget;
-        if (event.type !== 'touchmove' && ROOT_TARGET !== target) {
-          ROOT_TARGET = target;
-          SCROLLABLE_NODES = this._getScrollableNodes(Polymer.dom(event).path);
+        if (event.type !== 'touchmove' && lastRootTarget !== target) {
+          lastRootTarget = target;
+          lastScrollableNodes = this._getScrollableNodes(Polymer.dom(event).path);
         }
 
         // Prevent event if no scrollable nodes.
-        if (!SCROLLABLE_NODES.length) {
+        if (!lastScrollableNodes.length) {
           return true;
         }
         // Don't prevent touchstart event inside the locking element when it has
@@ -243,7 +249,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Get deltaX/Y.
         var info = this._getScrollInfo(event);
         // Prevent if there is no child that can scroll.
-        return !this._getScrollingNode(SCROLLABLE_NODES, info.deltaX, info.deltaY);
+        return !this._getScrollingNode(lastScrollableNodes, info.deltaX, info.deltaY);
       },
 
       /**
@@ -342,9 +348,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         else if (event.targetTouches) {
           var touch = event.targetTouches[0];
           // Touch moves from right to left => scrolling goes right.
-          info.deltaX = LAST_TOUCH_POSITION.pageX - touch.pageX;
+          info.deltaX = lastTouchPosition.pageX - touch.pageX;
           // Touch moves from down to up => scrolling goes down.
-          info.deltaY = LAST_TOUCH_POSITION.pageY - touch.pageY;
+          info.deltaY = lastTouchPosition.pageY - touch.pageY;
         }
         return info;
       }

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -200,23 +200,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._boundScrollHandler = this._boundScrollHandler ||
           this._scrollInteractionHandler.bind(this);
         // Modern `wheel` event for mouse wheel scrolling:
-        document.addEventListener('wheel', this._boundScrollHandler, true);
+        document.addEventListener('wheel', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
         // Older, non-standard `mousewheel` event for some FF:
-        document.addEventListener('mousewheel', this._boundScrollHandler, true);
+        document.addEventListener('mousewheel', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
         // IE:
-        document.addEventListener('DOMMouseScroll', this._boundScrollHandler, true);
+        document.addEventListener('DOMMouseScroll', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
         // Save the lastScrollableNodes on touchstart, to be used on touchmove.
-        document.addEventListener('touchstart', this._boundScrollHandler, true);
+        document.addEventListener('touchstart', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
         // Mobile devices can scroll on touch move:
-        document.addEventListener('touchmove', this._boundScrollHandler, true);
+        document.addEventListener('touchmove', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
       },
 
       _unlockScrollInteractions: function() {
-        document.removeEventListener('wheel', this._boundScrollHandler, true);
-        document.removeEventListener('mousewheel', this._boundScrollHandler, true);
-        document.removeEventListener('DOMMouseScroll', this._boundScrollHandler, true);
-        document.removeEventListener('touchstart', this._boundScrollHandler, true);
-        document.removeEventListener('touchmove', this._boundScrollHandler, true);
+        document.removeEventListener('wheel', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
+        document.removeEventListener('mousewheel', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
+        document.removeEventListener('DOMMouseScroll', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
+        document.removeEventListener('touchstart', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
+        document.removeEventListener('touchmove', this._boundScrollHandler, {
+          capture: true,
+          passive: false
+        });
       },
 
       /**

--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -31,6 +31,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     var lastScrollableNodes = [];
 
+    var scrollEvents = [
+      // Modern `wheel` event for mouse wheel scrolling:
+      'wheel',
+      // Older, non-standard `mousewheel` event for some FF:
+      'mousewheel',
+      // IE:
+      'DOMMouseScroll',
+      // Touch enabled devices
+      'touchstart',
+      'touchmove'
+    ];
+
     /**
      * The IronDropdownScrollManager is intended to provide a central source
      * of authority and control over which elements in a document are currently
@@ -199,54 +211,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _lockScrollInteractions: function() {
         this._boundScrollHandler = this._boundScrollHandler ||
           this._scrollInteractionHandler.bind(this);
-        // Modern `wheel` event for mouse wheel scrolling:
-        document.addEventListener('wheel', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        // Older, non-standard `mousewheel` event for some FF:
-        document.addEventListener('mousewheel', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        // IE:
-        document.addEventListener('DOMMouseScroll', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        // Save the lastScrollableNodes on touchstart, to be used on touchmove.
-        document.addEventListener('touchstart', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        // Mobile devices can scroll on touch move:
-        document.addEventListener('touchmove', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
+        for (var i = 0, l = scrollEvents.length; i < l; i++) {
+          // NOTE: browsers that don't support objects as third arg will
+          // interpret it as boolean, hence useCapture = true in this case. 
+          document.addEventListener(scrollEvents[i], this._boundScrollHandler, {
+            capture: true,
+            passive: false
+          });
+        }
       },
 
       _unlockScrollInteractions: function() {
-        document.removeEventListener('wheel', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        document.removeEventListener('mousewheel', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        document.removeEventListener('DOMMouseScroll', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        document.removeEventListener('touchstart', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
-        document.removeEventListener('touchmove', this._boundScrollHandler, {
-          capture: true,
-          passive: false
-        });
+        for (var i = 0, l = scrollEvents.length; i < l; i++) {
+          // NOTE: browsers that don't support objects as third arg will
+          // interpret it as boolean, hence useCapture = true in this case.
+          document.removeEventListener(scrollEvents[i], this._boundScrollHandler, {
+            capture: true,
+            passive: false
+          });
+        }
       },
 
       /**

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -195,7 +195,7 @@ method is called on the element.
 
         attached: function () {
           if (!this.sizingTarget || this.sizingTarget === this) {
-            this.sizingTarget = this.containedElement;
+            this.sizingTarget = this.containedElement || this;
           }
         },
 

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -173,12 +173,13 @@ method is called on the element.
          * The element that is contained by the dropdown, if any.
          */
         get containedElement() {
+          // Polymer 2.x returns slot.assignedNodes which can contain text nodes.
           var nodes = Polymer.dom(this.$.content).getDistributedNodes();
-          var i = 0;
-          while (nodes[i] && nodes[i].nodeType !== Node.ELEMENT_NODE) {
-            i++;
+          for (var i = 0, l = nodes.length; i < l; i++) {
+            if (nodes[i].nodeType === Node.ELEMENT_NODE) {
+              return nodes[i];
+            }
           }
-          return nodes[i];
         },
 
         ready: function() {

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -103,7 +103,7 @@ In the above example, the `<div>` will be hidden until the dropdown element has
            * details.
            */
           openAnimationConfig: {
-            type: Array
+            type: Object
           },
 
           /**
@@ -113,7 +113,7 @@ In the above example, the `<div>` will be hidden until the dropdown element has
            * details.
            */
           closeAnimationConfig: {
-            type: Array
+            type: Object
           },
 
           /**

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -14,7 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 <link rel="import" href="../neon-animation/neon-animation-runner-behavior.html">
-<link rel="import" href="../neon-animation/animations/opaque-animation.html">
 <link rel="import" href="iron-dropdown-scroll-manager.html">
 
 <!--

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -18,8 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <!--
 `<iron-dropdown>` is a generalized element that is useful when you have
-hidden content that is revealed due to some change in state that should cause it
-to do so.
+hidden content (`dropdown-content`) that is revealed due to some change in
+state that should cause it to do so.
 
 Note that this is a low-level element intended to be used as part of other
 composite elements that cause dropdowns to be revealed.
@@ -28,14 +28,16 @@ Examples of elements that might be implemented using an `iron-dropdown`
 include comboboxes, menubuttons, selects. The list goes on.
 
 The `<iron-dropdown>` element exposes attributes that allow the position
-of the content relative to a position target to be configured.
+of the `dropdown-content` relative to the `dropdown-trigger` to be
+configured.
 
     <iron-dropdown horizontal-align="right" vertical-align="top">
-      <div>Hello!</div>
+      <div slot="dropdown-content">Hello!</div>
     </iron-dropdown>
 
-In the above example, the `<div>` will be hidden until the dropdown element has
-`opened` set to true, or when the `open` method is called on the element.
+In the above example, the `<div>` with slot `dropdown-content` will be
+hidden until the dropdown element has `opened` set to true, or when the `open`
+method is called on the element.
 
 @demo demo/index.html
 -->

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -35,7 +35,7 @@ configured.
       <div slot="dropdown-content">Hello!</div>
     </iron-dropdown>
 
-In the above example, the `<div>` with slot `dropdown-content` will be
+In the above example, the `<div>` assigned to the `dropdown-content` slot will be
 hidden until the dropdown element has `opened` set to true, or when the `open`
 method is called on the element.
 

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -220,7 +220,7 @@ In the above example, the `<div>` will be hidden until the dropdown element has
             this._updateAnimationConfig();
             this._saveScrollPosition();
             if (this.opened) {
-              this.isAttached && document.addEventListener('scroll', this._boundOnCaptureScroll);
+              document.addEventListener('scroll', this._boundOnCaptureScroll);
               !this.allowOutsideScroll && Polymer.IronDropdownScrollManager.pushScrollLock(this);
             } else {
               document.removeEventListener('scroll', this._boundOnCaptureScroll);

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -45,20 +45,17 @@ In the above example, the `<div>` will be hidden until the dropdown element has
   <template>
     <style>
 
-      #contentWrapper ::slotted(*),
-      #contentWrapper ::content > * {
+      #contentWrapper ::slotted(*) {
         overflow: auto;
       }
 
-      #contentWrapper.animating ::slotted(*),
-      #contentWrapper.animating ::content > * {
+      #contentWrapper.animating ::slotted(*) {
         overflow: hidden;
       }
     </style>
 
     <div id="contentWrapper">
-      <content id="content"></content>
-      <slot id="slot"></slot>
+      <slot></slot>
     </div>
   </template>
 
@@ -183,7 +180,7 @@ In the above example, the `<div>` will be hidden until the dropdown element has
          * The element that is contained by the dropdown, if any.
          */
         get containedElement() {
-          var nodes = this._getDistributedNodes(this.$.slot, this.$.content);
+          var nodes = Polymer.dom(this.$.contentWrapper).getEffectiveChildNodes();
           var i = 0;
           while (nodes[i] && nodes[i].nodeType !== Node.ELEMENT_NODE) {
             i++;
@@ -351,19 +348,6 @@ In the above example, the `<div>` will be hidden until the dropdown element has
           } else {
             Polymer.IronOverlayBehaviorImpl._applyFocus.apply(this, arguments);
           }
-        },
-
-        /**
-         * Returns distributed nodes either from the slot or
-         * content (dual-mode support).
-         * @private
-         */
-        _getDistributedNodes: function(slot, content) {
-          var assigned = Polymer.dom(slot).assignedNodes({
-            flatten: true
-          });
-          var distributed = Polymer.dom(content).getDistributedNodes();
-          return assigned.length ? assigned : distributed;
         }
       });
     })();

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -57,7 +57,7 @@ In the above example, the `<div>` will be hidden until the dropdown element has
     </style>
 
     <div id="contentWrapper">
-      <slot id="content"></slot>
+      <slot id="content" name="dropdown-content"></slot>
     </div>
   </template>
 

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -189,6 +189,9 @@ In the above example, the `<div>` will be hidden until the dropdown element has
 
         attached: function () {
           if (!this.sizingTarget || this.sizingTarget === this) {
+            // Need to flush to force distribution in order to get the containedElement
+            //TODO(valdrin) remove flush when webcomponents/shadydom#56 is solved.
+            window.ShadyDOM && window.ShadyDOM.flush();
             this.sizingTarget = this.containedElement || this;
           }
         },

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -189,9 +189,6 @@ In the above example, the `<div>` will be hidden until the dropdown element has
 
         attached: function () {
           if (!this.sizingTarget || this.sizingTarget === this) {
-            // Need to flush to force distribution in order to get the containedElement
-            //TODO(valdrin) remove flush when webcomponents/shadydom#56 is solved.
-            window.ShadyDOM && window.ShadyDOM.flush();
             this.sizingTarget = this.containedElement || this;
           }
         },

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -44,6 +44,9 @@ In the above example, the `<div>` will be hidden until the dropdown element has
 <dom-module id="iron-dropdown">
   <template>
     <style>
+      :host {
+        position: fixed;
+      }
 
       #contentWrapper ::slotted(*) {
         overflow: auto;
@@ -55,7 +58,7 @@ In the above example, the `<div>` will be hidden until the dropdown element has
     </style>
 
     <div id="contentWrapper">
-      <slot></slot>
+      <slot id="content"></slot>
     </div>
   </template>
 
@@ -145,17 +148,6 @@ In the above example, the `<div>` will be hidden until the dropdown element has
           },
 
           /**
-           * The element that will receive a `max-height`/`width`. Overriden
-           * default value from `IronFitBehavior` to be the `containedElement` if
-           * not defined.
-           * @type {!Element}
-           */
-          sizingTarget: {
-            type: Object,
-            value: null
-          },
-
-          /**
            * Callback for scroll events.
            * @type {Function}
            * @private
@@ -180,7 +172,7 @@ In the above example, the `<div>` will be hidden until the dropdown element has
          * The element that is contained by the dropdown, if any.
          */
         get containedElement() {
-          var nodes = Polymer.dom(this.$.contentWrapper).getEffectiveChildNodes();
+          var nodes = Polymer.dom(this.$.content).getDistributedNodes();
           var i = 0;
           while (nodes[i] && nodes[i].nodeType !== Node.ELEMENT_NODE) {
             i++;

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -19,8 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <!--
 `<iron-dropdown>` is a generalized element that is useful when you have
-hidden content (`.dropdown-content`) that is revealed due to some change in
-state that should cause it to do so.
+hidden content that is revealed due to some change in state that should cause it
+to do so.
 
 Note that this is a low-level element intended to be used as part of other
 composite elements that cause dropdowns to be revealed.
@@ -29,16 +29,14 @@ Examples of elements that might be implemented using an `iron-dropdown`
 include comboboxes, menubuttons, selects. The list goes on.
 
 The `<iron-dropdown>` element exposes attributes that allow the position
-of the `.dropdown-content` relative to the `.dropdown-trigger` to be
-configured.
+of the content relative to a position target to be configured.
 
     <iron-dropdown horizontal-align="right" vertical-align="top">
-      <div class="dropdown-content">Hello!</div>
+      <div>Hello!</div>
     </iron-dropdown>
 
-In the above example, the `<div>` with class `.dropdown-content` will be
-hidden until the dropdown element has `opened` set to true, or when the `open`
-method is called on the element.
+In the above example, the `<div>` will be hidden until the dropdown element has
+`opened` set to true, or when the `open` method is called on the element.
 
 @demo demo/index.html
 -->
@@ -46,21 +44,21 @@ method is called on the element.
 <dom-module id="iron-dropdown">
   <template>
     <style>
-      :host {
-        position: fixed;
-      }
 
+      #contentWrapper ::slotted(*),
       #contentWrapper ::content > * {
         overflow: auto;
       }
 
+      #contentWrapper.animating ::slotted(*),
       #contentWrapper.animating ::content > * {
         overflow: hidden;
       }
     </style>
 
     <div id="contentWrapper">
-      <content id="content" select=".dropdown-content"></content>
+      <content id="content"></content>
+      <slot id="slot"></slot>
     </div>
   </template>
 
@@ -108,7 +106,7 @@ method is called on the element.
            * details.
            */
           openAnimationConfig: {
-            type: Object
+            type: Array
           },
 
           /**
@@ -118,7 +116,7 @@ method is called on the element.
            * details.
            */
           closeAnimationConfig: {
-            type: Object
+            type: Array
           },
 
           /**
@@ -150,6 +148,17 @@ method is called on the element.
           },
 
           /**
+           * The element that will receive a `max-height`/`width`. Overriden
+           * default value from `IronFitBehavior` to be the `containedElement` if
+           * not defined.
+           * @type {!Element}
+           */
+          sizingTarget: {
+            type: Object,
+            value: null
+          },
+
+          /**
            * Callback for scroll events.
            * @type {Function}
            * @private
@@ -174,15 +183,12 @@ method is called on the element.
          * The element that is contained by the dropdown, if any.
          */
         get containedElement() {
-          return Polymer.dom(this.$.content).getDistributedNodes()[0];
-        },
-
-        /**
-         * The element that should be focused when the dropdown opens.
-         * @deprecated
-         */
-        get _focusTarget() {
-          return this.focusTarget || this.containedElement;
+          var nodes = this._getDistributedNodes(this.$.slot, this.$.content);
+          var i = 0;
+          while (nodes[i] && nodes[i].nodeType !== Node.ELEMENT_NODE) {
+            i++;
+          }
+          return nodes[i];
         },
 
         ready: function() {
@@ -217,7 +223,7 @@ method is called on the element.
             this._updateAnimationConfig();
             this._saveScrollPosition();
             if (this.opened) {
-              document.addEventListener('scroll', this._boundOnCaptureScroll);
+              this.isAttached && document.addEventListener('scroll', this._boundOnCaptureScroll);
               !this.allowOutsideScroll && Polymer.IronDropdownScrollManager.pushScrollLock(this);
             } else {
               document.removeEventListener('scroll', this._boundOnCaptureScroll);
@@ -243,7 +249,6 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _renderClosed: function() {
-
           if (!this.noAnimations && this.animationConfig.close) {
             this.$.contentWrapper.classList.add('animating');
             this.playAnimation('close');
@@ -339,13 +344,26 @@ method is called on the element.
         /**
          * Apply focus to focusTarget or containedElement
          */
-        _applyFocus: function () {
+        _applyFocus: function() {
           var focusTarget = this.focusTarget || this.containedElement;
           if (focusTarget && this.opened && !this.noAutoFocus) {
             focusTarget.focus();
           } else {
             Polymer.IronOverlayBehaviorImpl._applyFocus.apply(this, arguments);
           }
+        },
+
+        /**
+         * Returns distributed nodes either from the slot or
+         * content (dual-mode support).
+         * @private
+         */
+        _getDistributedNodes: function(slot, content) {
+          var assigned = Polymer.dom(slot).assignedNodes({
+            flatten: true
+          });
+          var distributed = Polymer.dom(content).getDistributedNodes();
+          return assigned.length ? assigned : distributed;
         }
       });
     })();

--- a/test/index.html
+++ b/test/index.html
@@ -18,10 +18,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script>
     WCT.loadSuites([
-      'iron-dropdown.html',
-      'iron-dropdown-scroll-manager.html',
-      'iron-dropdown.html?dom=shadow',
-      'iron-dropdown-scroll-manager.html?dom=shadow'
+      'iron-dropdown.html?wc-shadydom=true&wc-ce=true', // shady
+      'iron-dropdown-scroll-manager.html?wc-shadydom=true&wc-ce=true', // shady
+      'iron-dropdown.html?dom=shadow', // shadow
+      'iron-dropdown-scroll-manager.html?dom=shadow' // shadow
     ]);
   </script>
 </body>

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -17,11 +17,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../iron-dropdown-scroll-manager.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="x-scrollable-element.html">
 </head>
 

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -124,7 +124,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           test('prevents wheel events from locked elements', function() {
             events.forEach(function(event) {
               childTwo.dispatchEvent(event);
-              expect(event.defaultPrevented).to.be.eql(true);
+              assert.isTrue(event.defaultPrevented, event.type + ' ok');
             });
           });
 
@@ -132,14 +132,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Polymer.IronDropdownScrollManager.removeScrollLock(childOne);
             events.forEach(function(event) {
               childTwo.dispatchEvent(event);
-              expect(event.defaultPrevented).to.be.eql(false);
+              assert.isFalse(event.defaultPrevented, event.type + ' ok');
             });
           });
 
           test('allows wheel events from unlocked elements', function() {
             events.forEach(function(event) {
               childOne.dispatchEvent(event);
-              expect(event.defaultPrevented).to.be.eql(false);
+              assert.isFalse(event.defaultPrevented, event.type + ' ok');
             });
           });
 
@@ -150,7 +150,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               composed: true
             });
             childTwo.dispatchEvent(event);
-            expect(event.defaultPrevented).to.be.eql(true);
+            assert.isTrue(event.defaultPrevented, event.type + ' ok');
           });
 
           test('touchstart is not prevented if dispatched by an element inside the locking element', function() {
@@ -160,7 +160,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               composed: true
             });
             grandChildOne.dispatchEvent(event);
-            expect(event.defaultPrevented).to.be.eql(false);
+            assert.isFalse(event.defaultPrevented, event.type + ' ok');
           });
 
           test('arrow keyboard events not prevented by manager', function() {
@@ -176,10 +176,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             grandChildOne.dispatchEvent(up);
             grandChildOne.dispatchEvent(right);
             grandChildOne.dispatchEvent(down);
-            expect(left.defaultPrevented).to.be.eql(false);
-            expect(up.defaultPrevented).to.be.eql(false);
-            expect(right.defaultPrevented).to.be.eql(false);
-            expect(down.defaultPrevented).to.be.eql(false);
+            assert.isFalse(left.defaultPrevented, 'left ok');
+            assert.isFalse(up.defaultPrevented, 'up ok');
+            assert.isFalse(right.defaultPrevented, 'right ok');
+            assert.isFalse(down.defaultPrevented, 'down ok');
           });
         });
       });

--- a/test/iron-dropdown-scroll-manager.html
+++ b/test/iron-dropdown-scroll-manager.html
@@ -112,7 +112,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             events = scrollEvents.map(function(scrollEvent) {
               var event = new CustomEvent(scrollEvent, {
                 bubbles: true,
-                cancelable: true
+                cancelable: true,
+                composed: true
               });
               event.deltaX = 0;
               event.deltaY = 10;
@@ -145,7 +146,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           test('touchstart is prevented if dispatched by an element outside the locking element', function() {
             var event = new CustomEvent('touchstart', {
               bubbles: true,
-              cancelable: true
+              cancelable: true,
+              composed: true
             });
             childTwo.dispatchEvent(event);
             expect(event.defaultPrevented).to.be.eql(true);
@@ -154,7 +156,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           test('touchstart is not prevented if dispatched by an element inside the locking element', function() {
             var event = new CustomEvent('touchstart', {
               bubbles: true,
-              cancelable: true
+              cancelable: true,
+              composed: true
             });
             grandChildOne.dispatchEvent(event);
             expect(event.defaultPrevented).to.be.eql(false);

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -145,6 +145,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="EmptyDropdown">
+    <template>
+      <iron-dropdown></iron-dropdown>
+    </template>
+  </test-fixture>
+
   <script>
     function elementIsVisible(element) {
       var contentRect = element.getBoundingClientRect();
@@ -231,6 +237,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(document.activeElement).to.be.equal(focusableChild);
               done();
             });
+          });
+        });
+
+        suite('when dropdown is empty', function() {
+          test('keeps the sizingTarget default value', function() {
+            dropdown = fixture('EmptyDropdown');
+            expect(dropdown.sizingTarget).to.be.equal(dropdown);
           });
         });
 

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -17,11 +17,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../iron-dropdown.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
 
 </head>
 <style>

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -44,7 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     left: 40px;
   }
 
-  .dropdown-content {
+  [slot="dropdown-content"] {
     width: 50px;
     height: 50px;
     background-color: orange;
@@ -61,7 +61,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="TrivialDropdown">
     <template>
       <iron-dropdown>
-        <div slot="dropdown-content" class="dropdown-content"></div>
+        <div slot="dropdown-content"></div>
       </iron-dropdown>
     </template>
   </test-fixture>
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="NonLockingDropdown">
     <template>
       <iron-dropdown allow-outside-scroll>
-        <div slot="dropdown-content" class="dropdown-content">I don't lock scroll!</div>
+        <div slot="dropdown-content">I don't lock scroll!</div>
       </iron-dropdown>
     </template>
   </test-fixture>
@@ -78,7 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div class="container">
         <iron-dropdown horizontal-align="right" vertical-align="top">
-          <div slot="dropdown-content" class="dropdown-content big"></div>
+          <div slot="dropdown-content" class="big"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -89,7 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div class="container positioned">
         <iron-dropdown>
-          <div slot="dropdown-content" class="dropdown-content"></div>
+          <div slot="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -99,7 +99,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div class="container positioned">
         <iron-dropdown horizontal-align="right" vertical-align="bottom">
-          <div slot="dropdown-content" class="dropdown-content"></div>
+          <div slot="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -108,7 +108,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="FocusableContentDropdown">
     <template>
       <iron-dropdown>
-        <div slot="dropdown-content" class="dropdown-content" tabindex="0">
+        <div slot="dropdown-content" tabindex="0">
           <div class="subcontent" tabindex="0"></div>
         </div>
       </iron-dropdown>
@@ -119,7 +119,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div dir="rtl" class="container">
         <iron-dropdown>
-          <div slot="dropdown-content" class="dropdown-content"></div>
+          <div slot="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -129,7 +129,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div dir="rtl" class="container">
         <iron-dropdown horizontal-align="right">
-          <div slot="dropdown-content" class="dropdown-content"></div>
+          <div slot="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -138,7 +138,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="sizingTarget">
     <template>
       <iron-dropdown>
-        <div slot="dropdown-content" class="dropdown-content">
+        <div slot="dropdown-content">
           <div class="subcontent"></div>
         </div>
       </iron-dropdown>
@@ -195,7 +195,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('basic', function() {
         setup(function() {
           dropdown = fixture('TrivialDropdown');
-          content = Polymer.dom(dropdown).querySelector('.dropdown-content');
+          content = Polymer.dom(dropdown).querySelector('[slot="dropdown-content"]');
         });
 
         test('effectively hides the dropdown content', function() {
@@ -223,7 +223,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('when content is focusable', function() {
           setup(function() {
             dropdown = fixture('FocusableContentDropdown');
-            content = Polymer.dom(dropdown).querySelector('.dropdown-content');
+            content = Polymer.dom(dropdown).querySelector('[slot="dropdown-content"]');
           });
           test('focuses the content when opened', function(done) {
             runAfterOpen(dropdown, function() {
@@ -570,7 +570,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('sizing target', function() {
         setup(function() {
           dropdown = fixture('sizingTarget');
-          content = Polymer.dom(dropdown).querySelector('.dropdown-content');
+          content = Polymer.dom(dropdown).querySelector('[slot="dropdown-content"]');
         });
 
         test('sizingTarget is the content element by default', function(done) {

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -170,7 +170,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // IE 11 doesn't support WheelEvent, use CustomEvent.
       var event = new CustomEvent('wheel', {
         cancelable: true,
-        bubbles: true
+        bubbles: true,
+        composed: true
       });
       event.deltaX = deltaX;
       event.deltaY = deltaY;
@@ -181,7 +182,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function dispatchScroll(target, scrollLeft, scrollTop) {
       target.scrollLeft = scrollLeft;
       target.scrollTop = scrollTop;
-      target.dispatchEvent(new CustomEvent('scroll', { bubbles:true } ));
+      target.dispatchEvent(new CustomEvent('scroll', {
+        bubbles: true,
+        composed: true
+      }));
     }
 
     suite('<iron-dropdown>', function() {

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -61,7 +61,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="TrivialDropdown">
     <template>
       <iron-dropdown>
-        <div class="dropdown-content"></div>
+        <div slot="dropdown-content" class="dropdown-content"></div>
       </iron-dropdown>
     </template>
   </test-fixture>
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="NonLockingDropdown">
     <template>
       <iron-dropdown allow-outside-scroll>
-        <div class="dropdown-content">I don't lock scroll!</div>
+        <div slot="dropdown-content" class="dropdown-content">I don't lock scroll!</div>
       </iron-dropdown>
     </template>
   </test-fixture>
@@ -78,7 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div class="container">
         <iron-dropdown horizontal-align="right" vertical-align="top">
-          <div class="dropdown-content big"></div>
+          <div slot="dropdown-content" class="dropdown-content big"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -89,7 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div class="container positioned">
         <iron-dropdown>
-          <div class="dropdown-content"></div>
+          <div slot="dropdown-content" class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -99,7 +99,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div class="container positioned">
         <iron-dropdown horizontal-align="right" vertical-align="bottom">
-          <div class="dropdown-content"></div>
+          <div slot="dropdown-content" class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -108,7 +108,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="FocusableContentDropdown">
     <template>
       <iron-dropdown>
-        <div class="dropdown-content" tabindex="0">
+        <div slot="dropdown-content" class="dropdown-content" tabindex="0">
           <div class="subcontent" tabindex="0"></div>
         </div>
       </iron-dropdown>
@@ -119,7 +119,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div dir="rtl" class="container">
         <iron-dropdown>
-          <div class="dropdown-content"></div>
+          <div slot="dropdown-content" class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -129,7 +129,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div dir="rtl" class="container">
         <iron-dropdown horizontal-align="right">
-          <div class="dropdown-content"></div>
+          <div slot="dropdown-content" class="dropdown-content"></div>
         </iron-dropdown>
       </div>
     </template>
@@ -138,7 +138,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="sizingTarget">
     <template>
       <iron-dropdown>
-        <div class="dropdown-content">
+        <div slot="dropdown-content" class="dropdown-content">
           <div class="subcontent"></div>
         </div>
       </iron-dropdown>


### PR DESCRIPTION
Relevant updates:
- use `demo-snippet` on demo page, add dev-dependency on `web-animations-js` as `neon-animation` doesn't anymore
- make events `composed` in the unit tests
- removed deprecated private property `_focusTarget`
- explicitly set scroll listeners to be `passive: false` as in Canary `touchstart, touchmove` listeners treat the target as passive by default https://bugs.chromium.org/p/chromium/issues/detail?id=652519