### PR TITLE
Implicitly close the dropdown if the element loses focus

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -343,19 +343,6 @@ method is called on the element.
         },
 
         /**
-         * An element related to the dropdown (the triggering element, or an
-         * element within the dropdown) has lost focus.
-         */
-        _activeElementBlurred: function(event) {
-          if (event.target._blurListener) {
-            // Stop listening to blur events on the target.
-            event.target.removeEventListener('blur', event.target._blurListener);
-            event.target._blurListener = null;
-          }
-          this._dropdownFocusChanged(false);
-        },
-
-        /**
          * Return true if the focus is anywhere within the dropdown.
          */
         _focusWithinDropdown: function() {

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -238,14 +238,6 @@ method is called on the element.
         /**
          * Overridden from `IronOverlayBehavior`.
          */
-        _finishRenderOpened: function() {
-          Polymer.IronOverlayBehaviorImpl._finishRenderOpened.apply(this, arguments);
-          this._dropdownFocusChanged(true);
-        },
-
-        /**
-         * Overridden from `IronOverlayBehavior`.
-         */
         _renderClosed: function() {
 
           if (!this.noAnimations && this.animationConfig.close) {
@@ -363,64 +355,6 @@ method is called on the element.
           this._dropdownFocusChanged(false);
         },
 
-        // The focus has changed, and we want to see whether it is now/still
-        // inside the dropdown, or whether it's moved outside the dropdown.
-        // As a special case, we also account for whether a dropdown was invoked
-        // but has no focusable element, in which case the focus should still be
-        // on the element (e.g., button) that triggered opening of the dropdown.
-        //
-        // Note: The focus check will happen *after* the iron-overlay-opened
-        // event has fired.
-        _dropdownFocusChanged: function(initialFocus) {
-          // Because this method is invoked in response to blur events, it can
-          // run after one element has lost focus, but before the next element
-          // has gotten the focus.
-          // We wait for the new activeElement to take effect.
-          this.async(function() {
-
-            var activeElement = this._manager.deepActiveElement;
-
-            // See if the focus is on the element that triggered the dropdown.
-            // When the overlay manager opens the dropdown, it records the node
-            // that currently has the focus. This is typically the element that
-            // triggered the display of the dropdown. Once the dropdown is
-            // open, the manager will (by default) try to apply the focus inside
-            // the dropdown. By the time we reach this point, if the focus is
-            // still on that original trigger element, then we can conclude the
-            // dropdown is not focusable. In that case, we want to track the
-            // blur event on that trigger element.
-            var focusOnTrigger = this._restoreFocusNode &&
-                this._restoreFocusNode === activeElement &&
-                this._restoreFocusNode !== document.body;
-
-            // See if the focus is somewhere within the dropdown.
-            var focusWithinDropdown = this._focusWithinDropdown();
-
-            if (focusOnTrigger || focusWithinDropdown) {
-              // Ask to be notified when the active element loses focus.
-              // REVIEW: In IE 11, there appear to be cases (e.g., in unit
-              // tests for this component) in which the activeElement will *not*
-              // expose addEventListener. Why?
-              if (activeElement.addEventListener) {
-                activeElement._blurListener = this._activeElementBlurred.bind(this);
-                activeElement.addEventListener('blur', activeElement._blurListener);
-              }
-            } else if (initialFocus) {
-              // The focus isn't anywhere we expect, even though this is the
-              // initial check we're doing while opening the dropdown. This
-              // means the dropdown was probably programmatically opened,
-              // rather than opened by the user. In that case, we can't track
-              // the focus, and won't do our auto-close behavior.
-              // So: do nothing.
-            } else if (this.opened) {
-              // The focus has moved away from the original trigger element, or
-              // moved outside of the dropdown, but the dropdown is still open.
-              // So, close it.
-              this.close();
-            }
-          });
-        },
-
         /**
          * Overridden from `IronOverlayBehavior`.
          */
@@ -443,6 +377,19 @@ method is called on the element.
           } else {
             var activeElement = this._manager.deepActiveElement;
             return Polymer.dom(this).deepContains(activeElement);
+          }
+        },
+
+        /**
+         * Overridden from `IronOverlayBehavior`.
+         */
+        _onCaptureFocus: function(event) {
+          if (!this._focusWithinDropdown()) {
+            // The focus has left the dropdown, e.g., in response to the user
+            // tabbing away. Implicitly cancel the dropdown.
+            this.cancel(event);
+          } else {
+            Polymer.IronOverlayBehaviorImpl._onCaptureFocus.apply(this, arguments);
           }
         }
       });

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -356,19 +356,6 @@ method is called on the element.
         },
 
         /**
-         * Overridden from `IronOverlayBehavior`.
-         */
-        _restoreFocusToNode: function(node) {
-          // Only restore focus to the indicated node if focus is currently
-          // somewhere within the dropdown. If focus is outside the dropdown, the
-          // user is likely trying to tab away, in which case it would be
-          // inappropriate to grab focus back.
-          if (this._focusWithinDropdown()) {
-            Polymer.IronOverlayBehaviorImpl._restoreFocusToNode.apply(this, arguments);
-          }
-        },
-
-        /**
          * Return true if the focus is anywhere within the dropdown.
          */
         _focusWithinDropdown: function() {
@@ -386,7 +373,12 @@ method is called on the element.
         _onCaptureFocus: function(event) {
           if (!this._focusWithinDropdown()) {
             // The focus has left the dropdown, e.g., in response to the user
-            // tabbing away. Implicitly cancel the dropdown.
+            // tabbing away.
+
+            // Avoid restoring focus after is closed.
+            this._restoreFocusNode = null;
+
+            // Implicitly cancel the dropdown.
             this.cancel(event);
           } else {
             Polymer.IronOverlayBehaviorImpl._onCaptureFocus.apply(this, arguments);

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -238,6 +238,14 @@ method is called on the element.
         /**
          * Overridden from `IronOverlayBehavior`.
          */
+        _finishRenderOpened: function() {
+          Polymer.IronOverlayBehaviorImpl._finishRenderOpened.apply(this, arguments);
+          this._dropdownFocusChanged(true);
+        },
+
+        /**
+         * Overridden from `IronOverlayBehavior`.
+         */
         _renderClosed: function() {
 
           if (!this.noAnimations && this.animationConfig.close) {
@@ -339,6 +347,102 @@ method is called on the element.
             focusTarget.focus();
           } else {
             Polymer.IronOverlayBehaviorImpl._applyFocus.apply(this, arguments);
+          }
+        },
+
+        /**
+         * An element related to the dropdown (the triggering element, or an
+         * element within the dropdown) has lost focus.
+         */
+        _activeElementBlurred: function(event) {
+          if (event.target._blurListener) {
+            // Stop listening to blur events on the target.
+            event.target.removeEventListener('blur', event.target._blurListener);
+            event.target._blurListener = null;
+          }
+          this._dropdownFocusChanged(false);
+        },
+
+        // The focus has changed, and we want to see whether it is now/still
+        // inside the dropdown, or whether it's moved outside the dropdown.
+        // As a special case, we also account for whether a dropdown was invoked
+        // but has no focusable element, in which case the focus should still be
+        // on the element (e.g., button) that triggered opening of the dropdown.
+        //
+        // Note: The focus check will happen *after* the iron-overlay-opened
+        // event has fired.
+        _dropdownFocusChanged: function(initialFocus) {
+          // Because this method is invoked in response to blur events, it can
+          // run after one element has lost focus, but before the next element
+          // has gotten the focus.
+          // We wait for the new activeElement to take effect.
+          this.async(function() {
+
+            var activeElement = this._manager.deepActiveElement;
+
+            // See if the focus is on the element that triggered the dropdown.
+            // When the overlay manager opens the dropdown, it records the node
+            // that currently has the focus. This is typically the element that
+            // triggered the display of the dropdown. Once the dropdown is
+            // open, the manager will (by default) try to apply the focus inside
+            // the dropdown. By the time we reach this point, if the focus is
+            // still on that original trigger element, then we can conclude the
+            // dropdown is not focusable. In that case, we want to track the
+            // blur event on that trigger element.
+            var focusOnTrigger = this._restoreFocusNode &&
+                this._restoreFocusNode === activeElement &&
+                this._restoreFocusNode !== document.body;
+
+            // See if the focus is somewhere within the dropdown.
+            var focusWithinDropdown = this._focusWithinDropdown();
+
+            if (focusOnTrigger || focusWithinDropdown) {
+              // Ask to be notified when the active element loses focus.
+              // REVIEW: In IE 11, there appear to be cases (e.g., in unit
+              // tests for this component) in which the activeElement will *not*
+              // expose addEventListener. Why?
+              if (activeElement.addEventListener) {
+                activeElement._blurListener = this._activeElementBlurred.bind(this);
+                activeElement.addEventListener('blur', activeElement._blurListener);
+              }
+            } else if (initialFocus) {
+              // The focus isn't anywhere we expect, even though this is the
+              // initial check we're doing while opening the dropdown. This
+              // means the dropdown was probably programmatically opened,
+              // rather than opened by the user. In that case, we can't track
+              // the focus, and won't do our auto-close behavior.
+              // So: do nothing.
+            } else if (this.opened) {
+              // The focus has moved away from the original trigger element, or
+              // moved outside of the dropdown, but the dropdown is still open.
+              // So, close it.
+              this.close();
+            }
+          });
+        },
+
+        /**
+         * Overridden from `IronOverlayBehavior`.
+         */
+        _restoreFocusToNode: function(node) {
+          // Only restore focus to the indicated node if focus is currently
+          // somewhere within the dropdown. If focus is outside the dropdown, the
+          // user is likely trying to tab away, in which case it would be
+          // inappropriate to grab focus back.
+          if (this._focusWithinDropdown()) {
+            Polymer.IronOverlayBehaviorImpl._restoreFocusToNode.apply(this, arguments);
+          }
+        },
+
+        /**
+         * Return true if the focus is anywhere within the dropdown.
+         */
+        _focusWithinDropdown: function() {
+          if (this.shadowRoot) {
+            return this.shadowRoot.activeElement !== null;
+          } else {
+            var activeElement = this._manager.deepActiveElement;
+            return Polymer.dom(this).deepContains(activeElement);
           }
         }
       });

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -358,6 +358,10 @@ method is called on the element.
          * Overridden from `IronOverlayBehavior`.
          */
         _onCaptureFocus: function(event) {
+          // See if the focus is still in the dropdown.
+          // In theory, a faster way to check this would be to inspect the event
+          // path and see where the focus is now. However, that gets tricky with
+          // synthetic focus events, such as those fired by iron-control-state.
           if (!this._focusWithinDropdown()) {
             // The focus has left the dropdown, e.g., in response to the user
             // tabbing away.

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -144,16 +144,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-dropdown>
     </template>
   </test-fixture>
-  
-  <test-fixture id="FocusableDropdownWithAnotherFocusableElement">
+
+  <test-fixture id="FocusableDropdownWithOtherFocusableElements">
     <template>
       <div>
+        <button id="focusableButton1">Button 1</button>
         <iron-dropdown>
           <div class="dropdown-content" tabindex="0">
             <div class="subcontent" tabindex="0"></div>
           </div>
         </iron-dropdown>
-        <button>A focusable button</button>
+        <button id="focusableButton2">Button 2</button>
       </div>
     </template>
   </test-fixture>
@@ -525,52 +526,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
       });
-      
-      suite('auto-close on blur', function() {
 
-        test('auto-close when focusable dropdown blurs', function(done) {
-          var elements = fixture('FocusableDropdownWithAnotherFocusableElement');
+      suite('auto-cancel on blur', function() {
+
+        test('auto-cancel when focusable dropdown blurs', function(done) {
+          var elements = fixture('FocusableDropdownWithOtherFocusableElements');
           var dropdown = Polymer.dom(elements).querySelector('iron-dropdown');
           var content = Polymer.dom(dropdown).querySelector('.dropdown-content');
-          var button = Polymer.dom(elements).querySelector('button');
+          var button1 = Polymer.dom(elements).querySelector('#focusableButton1');
+          var button2 = Polymer.dom(elements).querySelector('#focusableButton2');
 
+          // Step 1: First button gets focus.
+          button1.addEventListener('focus', function() {
+            dropdown.open();
+            runAfterOpen(dropdown, function() {
+              // Opening the dropdown moves focus to the dropdown content, but
+              // not if the window doesn't have focus, so to cover that case we
+              // have to simulate a focus event.
+              MockInteractions.focus(content);
+            });
+          });
+
+          // Step 2: Dropdown content gets focus after opening.
+          content.addEventListener('focus', function() {
+            // Move focus outside the dropdown to trigger auto-cancel behavior.
+            // To cover both interactive and automated testing, we need to do
+            // both a real focus and simulated focus change.
+            button2.focus();
+            MockInteractions.focus(button2);
+          });
+
+          // Step 3: Dropdown closes after second button gets focus.
           dropdown.addEventListener('iron-overlay-closed', function(event) {
-            // The iron-overlay-canceled event fires before the dropdown is
-            // closed, which is unfortunate. We have to wait before checking to
-            // make sure the dropdown was closed.
+            // The iron-overlay-closed event fires before the dropdown closes,
+            // which is unfortunate. Wait before checking dropdown was closed.
             Polymer.Base.async(function() {
               assert(!dropdown.opened);
               done();
             });
           });
 
-          // We wait until the button (outside the dropdown) has focus.
-          button.addEventListener('focus', function() {
-            runAfterOpen(dropdown, function() {
-              // Opening the dropdown should move focus to the dropdown content.
-              assert.equal(document.activeElement, content);
-              // Move the focus somewhere outside the dropdown in order to
-              // trigger the auto-close behavior. Since the iron-overlay-opened
-              // event fires before the focus has settled on the dropdown
-              // content, we have to wait before moving the focus away. Note:
-              // need task (not microtask) timing here.
-              setTimeout(function() {
-                // The note on simulating focus (below) applies to blur as well.
-                content.blur();
-                MockInteractions.blur(content);
-              }, 100); // Delay necessary for Edge/IE.
-            });
-          });
-
-          // Browsers seem to suppress or delay focus events if the window is
-          // not active, e.g., when running automated tests. So if we just use
-          // the native focus() method, the focus event won't fire. On the other
-          // hand, if we just use the mock focus() method, the activeElement
-          // won't be set correctly. A combination of both feels like overkill,
-          // but seems to accomplish the result of producing the right focus
-          // effects in both an active and inactive window.
-          button.focus();
-          MockInteractions.focus(button);
+          // Begin step 1 by moving focus to first button.
+          MockInteractions.focus(button1);
         });
       });
     });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -144,6 +144,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-dropdown>
     </template>
   </test-fixture>
+  
+  <test-fixture id="FocusableDropdownWithAnotherFocusableElement">
+    <template>
+      <div>
+        <iron-dropdown>
+          <div class="dropdown-content" tabindex="0">
+            <div class="subcontent" tabindex="0"></div>
+          </div>
+        </iron-dropdown>
+        <button>A focusable button</button>
+      </div>
+    </template>
+  </test-fixture>
 
   <script>
     function elementIsVisible(element) {
@@ -216,7 +229,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             content = Polymer.dom(dropdown).querySelector('.dropdown-content');
           });
           test('focuses the content when opened', function(done) {
-            runAfterOpen(dropdown, function() {
+            runAfterOpen(dropdown, function () {
               expect(document.activeElement).to.be.equal(content);
               done();
             });
@@ -510,6 +523,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(subcontent.style.maxWidth).to.be.not.empty;
             done();
           });
+        });
+      });
+      
+      suite('auto-close on blur', function() {
+
+        test('auto-close when focusable dropdown blurs', function(done) {
+          var elements = fixture('FocusableDropdownWithAnotherFocusableElement');
+          var dropdown = Polymer.dom(elements).querySelector('iron-dropdown');
+          var content = Polymer.dom(dropdown).querySelector('.dropdown-content');
+          var button = Polymer.dom(elements).querySelector('button');
+
+          dropdown.addEventListener('iron-overlay-closed', function(event) {
+            // The iron-overlay-canceled event fires before the dropdown is
+            // closed, which is unfortunate. We have to wait before checking to
+            // make sure the dropdown was closed.
+            Polymer.Base.async(function() {
+              assert(!dropdown.opened);
+              done();
+            });
+          });
+
+          // We wait until the button (outside the dropdown) has focus.
+          button.addEventListener('focus', function() {
+            runAfterOpen(dropdown, function() {
+              // Opening the dropdown should move focus to the dropdown content.
+              assert.equal(document.activeElement, content);
+              // Move the focus somewhere outside the dropdown in order to
+              // trigger the auto-close behavior. Since the iron-overlay-opened
+              // event fires before the focus has settled on the dropdown
+              // content, we have to wait before moving the focus away. Note:
+              // need task (not microtask) timing here.
+              setTimeout(function() {
+                // The note on simulating focus (below) applies to blur as well.
+                content.blur();
+                MockInteractions.blur(content);
+              }, 100); // Delay necessary for Edge/IE.
+            });
+          });
+
+          // Browsers seem to suppress or delay focus events if the window is
+          // not active, e.g., when running automated tests. So if we just use
+          // the native focus() method, the focus event won't fire. On the other
+          // hand, if we just use the mock focus() method, the activeElement
+          // won't be set correctly. A combination of both feels like overkill,
+          // but seems to accomplish the result of producing the right focus
+          // effects in both an active and inactive window.
+          button.focus();
+          MockInteractions.focus(button);
         });
       });
     });

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -145,16 +145,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="FocusableDropdownWithOtherFocusableElements">
+  <test-fixture id="FocusableDropdownWithOtherFocusableElement">
     <template>
       <div>
-        <button id="focusableButton1">Button 1</button>
         <iron-dropdown>
           <div class="dropdown-content" tabindex="0">
             <div class="subcontent" tabindex="0"></div>
           </div>
         </iron-dropdown>
-        <button id="focusableButton2">Button 2</button>
+        <button id="focusableButton">Button 2</button>
       </div>
     </template>
   </test-fixture>
@@ -190,6 +189,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       target.scrollLeft = scrollLeft;
       target.scrollTop = scrollTop;
       target.dispatchEvent(new CustomEvent('scroll', { bubbles:true } ));
+    }
+
+    // Ensure target both gets focus and raises a focus event.
+    function mockFocusAndEvent(target) {
+      var focusListenerCalled;
+      var focusListener = target.addEventListener('focus', function() {
+        focusListenerCalled = true;
+      })
+      target.focus();
+      target.removeEventListener('focus', focusListener);
+      // If the focus handler above hasn't run yet, the window is inactive, and
+      // won't generate focus events, so we'll need to simulate a focus event.
+      // However, stupid IE 11 doesn't run this focus handler synchronously as
+      // expected, so we need to wait to give the handler above time to run
+      // first.
+      setTimeout(function() {
+        if (!focusListenerCalled) {
+          // Focus events aren't being raised; simulate a focus event.
+          MockInteractions.focus(target);
+        }
+      }, 50);
     }
 
     suite('<iron-dropdown>', function() {
@@ -530,44 +550,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('auto-cancel on blur', function() {
 
         test('auto-cancel when focusable dropdown blurs', function(done) {
-          var elements = fixture('FocusableDropdownWithOtherFocusableElements');
+          var elements = fixture('FocusableDropdownWithOtherFocusableElement');
           var dropdown = Polymer.dom(elements).querySelector('iron-dropdown');
           var content = Polymer.dom(dropdown).querySelector('.dropdown-content');
-          var button1 = Polymer.dom(elements).querySelector('#focusableButton1');
-          var button2 = Polymer.dom(elements).querySelector('#focusableButton2');
+          var button = Polymer.dom(elements).querySelector('#focusableButton');
+          var mockDropdownFocus = true;
 
-          // Step 1: First button gets focus.
-          button1.addEventListener('focus', function() {
-            dropdown.open();
-            runAfterOpen(dropdown, function() {
-              // Opening the dropdown moves focus to the dropdown content, but
-              // not if the window doesn't have focus, so to cover that case we
-              // have to simulate a focus event.
-              MockInteractions.focus(content);
-            });
-          });
+          var canceledSpy = sinon.spy();
+          dropdown.addEventListener('iron-overlay-canceled', canceledSpy);
+          var contentGotFocus = false;
 
-          // Step 2: Dropdown content gets focus after opening.
+          // Step 1: Wait for dropdown to get focus after opening.
           content.addEventListener('focus', function() {
+            contentGotFocus = true;
             // Move focus outside the dropdown to trigger auto-cancel behavior.
-            // To cover both interactive and automated testing, we need to do
-            // both a real focus and simulated focus change.
-            button2.focus();
-            MockInteractions.focus(button2);
+            mockFocusAndEvent(button);
           });
 
-          // Step 3: Dropdown closes after second button gets focus.
-          dropdown.addEventListener('iron-overlay-closed', function(event) {
-            // The iron-overlay-closed event fires before the dropdown closes,
-            // which is unfortunate. Wait before checking dropdown was closed.
-            Polymer.Base.async(function() {
-              assert(!dropdown.opened);
-              done();
-            });
+          // Step 2: Wait for dropdopwn to close.
+          dropdown.addEventListener('iron-overlay-closed', function() {
+            assert(canceledSpy.calledOnce, 'dropdown raises iron-overlay-canceled on blur');
+            assert(!dropdown.opened, 'dropdown closed on blur');
+            done();
           });
 
-          // Begin step 1 by moving focus to first button.
-          MockInteractions.focus(button1);
+          // Start step 1.
+          runAfterOpen(dropdown, function() {
+            // If the content focus handler hasn't run, it's probably because
+            // the window is inactive. We'll need to simulate a focus event.
+            setTimeout(function() {
+              if (!contentGotFocus) {
+                MockInteractions.focus(content);
+              }
+            }, 50);
+          });
         });
       });
     });


### PR DESCRIPTION
Submitting for review — please hold off on merging.

This fixes PolymerElements/paper-dropdown-menu#141. See [this comment](https://github.com/PolymerElements/paper-dropdown-menu/issues/141#issuecomment-231518822) for a discussion of the approach here.

This fix depends on https://github.com/PolymerElements/iron-overlay-behavior/pull/219, which gives iron-dropdown a hook so it can refine the focus behavior.

@valdrinkoshi This is the second piece of the fix. Since you've been doing a lot of work in this area, I especially want to make sure this doesn't conflict with your work in progress.
