### PR TITLE
Default to host when contentElement not available

### DIFF
--- a/iron-dropdown-scroll-manager.html
+++ b/iron-dropdown-scroll-manager.html
@@ -13,8 +13,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   (function() {
     'use strict';
-    // Used to calculate the scroll direction during touch events.
-    var LAST_TOUCH_POSITION = {
+    /**
+     * Used to calculate the scroll direction during touch events.
+     * @type {!Object}
+     */
+    var lastTouchPosition = {
       pageX: 0,
       pageY: 0
     };
@@ -22,8 +25,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Used to avoid computing event.path and filter scrollable nodes (better perf).
      * @type {?EventTarget}
      */
-    var ROOT_TARGET = null;
-    var SCROLLABLE_NODES = [];
+    var lastRootTarget = null;
+    /**
+     * @type {!Array<Node>}
+     */
+    var lastScrollableNodes = [];
 
     /**
      * The IronDropdownScrollManager is intended to provide a central source
@@ -185,8 +191,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // If event has targetTouches (touch event), update last touch position.
         if (event.targetTouches) {
           var touch = event.targetTouches[0];
-          LAST_TOUCH_POSITION.pageX = touch.pageX;
-          LAST_TOUCH_POSITION.pageY = touch.pageY;
+          lastTouchPosition.pageX = touch.pageX;
+          lastTouchPosition.pageY = touch.pageY;
         }
       },
 
@@ -199,7 +205,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.addEventListener('mousewheel', this._boundScrollHandler, true);
         // IE:
         document.addEventListener('DOMMouseScroll', this._boundScrollHandler, true);
-        // Save the SCROLLABLE_NODES on touchstart, to be used on touchmove.
+        // Save the lastScrollableNodes on touchstart, to be used on touchmove.
         document.addEventListener('touchstart', this._boundScrollHandler, true);
         // Mobile devices can scroll on touch move:
         document.addEventListener('touchmove', this._boundScrollHandler, true);
@@ -226,13 +232,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Update if root target changed. For touch events, ensure we don't
         // update during touchmove.
         var target = Polymer.dom(event).rootTarget;
-        if (event.type !== 'touchmove' && ROOT_TARGET !== target) {
-          ROOT_TARGET = target;
-          SCROLLABLE_NODES = this._getScrollableNodes(Polymer.dom(event).path);
+        if (event.type !== 'touchmove' && lastRootTarget !== target) {
+          lastRootTarget = target;
+          lastScrollableNodes = this._getScrollableNodes(Polymer.dom(event).path);
         }
 
         // Prevent event if no scrollable nodes.
-        if (!SCROLLABLE_NODES.length) {
+        if (!lastScrollableNodes.length) {
           return true;
         }
         // Don't prevent touchstart event inside the locking element when it has
@@ -243,7 +249,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Get deltaX/Y.
         var info = this._getScrollInfo(event);
         // Prevent if there is no child that can scroll.
-        return !this._getScrollingNode(SCROLLABLE_NODES, info.deltaX, info.deltaY);
+        return !this._getScrollingNode(lastScrollableNodes, info.deltaX, info.deltaY);
       },
 
       /**
@@ -342,9 +348,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         else if (event.targetTouches) {
           var touch = event.targetTouches[0];
           // Touch moves from right to left => scrolling goes right.
-          info.deltaX = LAST_TOUCH_POSITION.pageX - touch.pageX;
+          info.deltaX = lastTouchPosition.pageX - touch.pageX;
           // Touch moves from down to up => scrolling goes down.
-          info.deltaY = LAST_TOUCH_POSITION.pageY - touch.pageY;
+          info.deltaY = lastTouchPosition.pageY - touch.pageY;
         }
         return info;
       }

--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -195,7 +195,7 @@ method is called on the element.
 
         attached: function () {
           if (!this.sizingTarget || this.sizingTarget === this) {
-            this.sizingTarget = this.containedElement;
+            this.sizingTarget = this.containedElement || this;
           }
         },
 

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -145,6 +145,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="EmptyDropdown">
+    <template>
+      <iron-dropdown></iron-dropdown>
+    </template>
+  </test-fixture>
+
   <script>
     function elementIsVisible(element) {
       var contentRect = element.getBoundingClientRect();
@@ -231,6 +237,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(document.activeElement).to.be.equal(focusableChild);
               done();
             });
+          });
+        });
+
+        suite('when dropdown is empty', function() {
+          test('keeps the sizingTarget default value', function() {
+            dropdown = fixture('EmptyDropdown');
+            expect(dropdown.sizingTarget).to.be.equal(dropdown);
           });
         });
 


### PR DESCRIPTION
Fixes #118 by defaulting to `this` if no `contentElement` is available.
Also, lower-cased variables since they're not constants.