### PR TITLE
only call _saveScrollPosition on opened

### DIFF
--- a/iron-dropdown.html
+++ b/iron-dropdown.html
@@ -215,8 +215,8 @@ method is called on the element.
           } else {
             this.cancelAnimation();
             this._updateAnimationConfig();
-            this._saveScrollPosition();
             if (this.opened) {
+              this._saveScrollPosition();
               document.addEventListener('scroll', this._boundOnCaptureScroll);
               !this.allowOutsideScroll && Polymer.IronDropdownScrollManager.pushScrollLock(this);
             } else {


### PR DESCRIPTION
_saveScrollPosition looks at scrollTop and scrollLeft, which are causing layout reflow (https://gist.github.com/paulirish/5d52fb081b3570c81e3a). 

When the element is first created and opened is false we still go through this function even though we don't necessary need to save the scroll pos at this point. Saving them when first opening is enough since the event listener on scroll is not attached before we're open anyway.

When closing the scroll event listener is removed and will be reattached on next open, when we'll get the new scroll values.

In our case having about ~35 hidden menu ends up adding a significant impact at initialization time (about 200ms with x5 cpu throttling).

Solves #112 