### PR TITLE
animations polyfill import to script

### DIFF
--- a/demo/grow-height-animation.html
+++ b/demo/grow-height-animation.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../neon-animation/neon-animation-behavior.html">
 
 <script>
   Polymer({

--- a/demo/grow-height-animation.html
+++ b/demo/grow-height-animation.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../neon-animation/neon-animation-behavior.html">
 
 <script>
   Polymer({

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,11 +15,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <title>iron-dropdown</title>
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-animations-js/web-animations-next-lite.min.js"></script>
 
   <link rel="import" href="../../iron-image/iron-image.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
-  <link rel="import" href="../../neon-animation/web-animations.html">
 
   <link rel="import" href="x-select.html">
 

--- a/demo/x-select.html
+++ b/demo/x-select.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../iron-dropdown.html">
-<link rel="import" href="../../neon-animation/neon-animations.html">
 <link rel="import" href="grow-height-animation.html">
 
 <dom-module id="x-select">

--- a/test/iron-dropdown.html
+++ b/test/iron-dropdown.html
@@ -18,9 +18,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
+  <script src="../../web-animations-js/web-animations-next-lite.min.js"></script>
 
   <link rel="import" href="../iron-dropdown.html">
-  <link rel="import" href="../../neon-animation/web-animations.html">
   <link rel="import" href="../../neon-animation/animations/fade-in-animation.html">
 
 </head>


### PR DESCRIPTION
fixes modulizer. We can't use the html import version of this because we can't use the minified polyfill in an es6 module.