### PR TITLE
Use "export * from" for iron-dropdown-scroll-manager alias

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,7 +1,0 @@
-{
-  "addReferences": {
-    "iron-dropdown-scroll-manager.d.ts": [
-      "iron-dropdown-scroll-manager-extra.d.ts"
-    ]
-  }
-}


### PR DESCRIPTION
This seems like a more straightforward way to modulize the alias file.

Also remove `gen-tsd.json` from 2.0. We don't need it because the generator understands `export * from` syntax.